### PR TITLE
Add dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    open-pull-requests-limit: 10
+    directory: "/db"
+    schedule:
+      interval: "monthly"
+    groups:
+      gomod-backward-compatible:
+        update-types:
+          - minor
+          - patch
+  - package-ecosystem: github-actions
+    open-pull-requests-limit: 5
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions-backward-compatible:
+        update-types:
+          - minor
+          - patch
+  - package-ecosystem: npm
+    open-pull-requests-limit: 5
+    directory: "/web"
+    schedule:
+      interval: "monthly"
+    groups:
+      npm-backward-compatible:
+        update-types:
+          - minor
+          - patch
+  - package-ecosystem: npm
+    open-pull-requests-limit: 5
+    directory: "/docs"
+    schedule:
+      interval: "monthly"
+    groups:
+      docker-backward-compatible:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
Add dependabot updates for Go packages, npm packages (for web and docs) and GitHub actions.

Only run those monthly and group minor and patch updates to keep the number of PRs low.