### PR TITLE
Fix oidc2 and oidc3 logos

### DIFF
--- a/web/src/routes/api/v1/auth/oauth/+server.ts
+++ b/web/src/routes/api/v1/auth/oauth/+server.ts
@@ -12,7 +12,7 @@ export async function GET(event: RequestEvent) {
         const r = await event.locals.pb.collection('users').listAuthMethods();
 
         for (const provider of r.oauth2.providers) {
-            const imageURL = `${env.PUBLIC_POCKETBASE_URL}/_/images/oauth2/${provider.name.replace(/[0-9]/g, '')}.svg`
+            const imageURL = `${env.PUBLIC_POCKETBASE_URL}/_/images/oauth2/${provider.name.replace(/\s*\(\d+\)$/, '')}.svg`
             provider['img' as keyof typeof provider] = await imageUrlToBase64(imageURL, event.fetch);
             provider['url' as keyof typeof provider] = `${provider.authURL}${redirectURL}`
         }


### PR DESCRIPTION
When looping through providers and getting images for the providers it uses the provider name to get the log which is correct for all logos except the OIDC (2) and OIDC (3) providers which use the same logo as OIDC (`oidc.svg`).
If you add the second or third option then the login page throws a 500 error because the image couldn't be found.

This just strips the numbers. Not the most elegant solution but it shouldn't break any of the other existing providers.