### PR TITLE
Fix swapped options for auto and bicycle routing

### DIFF
--- a/web/src/lib/stores/valhalla_store.svelte.ts
+++ b/web/src/lib/stores/valhalla_store.svelte.ts
@@ -62,12 +62,11 @@ export async function calculateRouteBetween(startLat: number, startLon: number, 
         let costingBody;
         switch (options.modeOfTransport) {
             case "bicycle":
-                costingBody = { "costing": options.modeOfTransport, "costing_options": { [options.modeOfTransport]: options.autoOptions } }
-                break;
-            case "auto":
                 costingBody = { "costing": options.modeOfTransport, "costing_options": { [options.modeOfTransport]: options.bicycleOptions } }
                 break;
-
+            case "auto":
+                costingBody = { "costing": options.modeOfTransport, "costing_options": { [options.modeOfTransport]: options.autoOptions } }
+                break;
             case "pedestrian":
                 costingBody = { "costing": options.modeOfTransport, "costing_options": { [options.modeOfTransport]: options.pedestrianOptions } }
                 break;


### PR DESCRIPTION
Fixes #548 / #424 (there was a simple mistake of using bicycle options when doing car routing and vice versa)