### PR TITLE
fix "amenity" spelling for better translations

### DIFF
--- a/web/src/lib/i18n/locales/de.json
+++ b/web/src/lib/i18n/locales/de.json
@@ -20,7 +20,7 @@
   "alphabetical": "Alphabetisch",
   "already-account": "Du hast bereits ein Konto?",
   "altitude": "Höhe",
-  "ammenity": "Ammenity",
+  "amenity": "Amenity",
   "api-documentation": "API Dokumentation",
   "attraction": "Sehenswürdigkeit",
   "author": "Autor",

--- a/web/src/lib/i18n/locales/en.json
+++ b/web/src/lib/i18n/locales/en.json
@@ -20,7 +20,7 @@
   "alphabetical": "Alphabetical",
   "already-account": "Already have an account?",
   "altitude": "Altitude",
-  "ammenity": "Ammenity",
+  "amenity": "Amenity",
   "api-documentation": "API Documentation",
   "attraction": "Attraction",
   "author": "Author",

--- a/web/src/lib/i18n/locales/es.json
+++ b/web/src/lib/i18n/locales/es.json
@@ -20,7 +20,7 @@
   "alphabetical": "Alfabético",
   "already-account": "¿Ya tienes una cuenta?",
   "altitude": "Altitud",
-  "ammenity": "Ammenity",
+  "amenity": "Amenity",
   "api-documentation": "Documentación API",
   "attraction": "Attraction",
   "author": "Autor",

--- a/web/src/lib/i18n/locales/eu.json
+++ b/web/src/lib/i18n/locales/eu.json
@@ -20,7 +20,7 @@
   "alphabetical": "Alfabetikoa",
   "already-account": "Baduzu kontua lehendik?",
   "altitude": "Altuera",
-  "ammenity": "Altimetria",
+  "amenity": "Altimetria",
   "api-documentation": "API dokumentazioa",
   "attraction": "Erakarmena",
   "author": "Egilea",

--- a/web/src/lib/i18n/locales/fr.json
+++ b/web/src/lib/i18n/locales/fr.json
@@ -20,7 +20,7 @@
   "alphabetical": "Alphabétique",
   "already-account": "Déjà un compte ?",
   "altitude": "Altitude",
-  "ammenity": "Ammenity",
+  "amenity": "Amenity",
   "api-documentation": "Documentation API",
   "attraction": "Attraction",
   "author": "Auteur",

--- a/web/src/lib/i18n/locales/hu.json
+++ b/web/src/lib/i18n/locales/hu.json
@@ -20,7 +20,7 @@
   "alphabetical": "Betűrendben",
   "already-account": "Már rendelkezik fiókkal?",
   "altitude": "Magasság",
-  "ammenity": "Ammenity",
+  "amenity": "Amenity",
   "api-documentation": "API Dokumentáció",
   "attraction": "Attraction",
   "author": "Author",

--- a/web/src/lib/i18n/locales/it.json
+++ b/web/src/lib/i18n/locales/it.json
@@ -20,7 +20,7 @@
   "alphabetical": "Alfabetico",
   "already-account": "Hai già un account?",
   "altitude": "Altitudine",
-  "ammenity": "Ammenity",
+  "amenity": "Amenity",
   "api-documentation": "Documentazione API",
   "attraction": "Attraction",
   "author": "Autore",

--- a/web/src/lib/i18n/locales/nl.json
+++ b/web/src/lib/i18n/locales/nl.json
@@ -20,7 +20,7 @@
   "alphabetical": "Alfabetisch",
   "already-account": "Heb je al een account?",
   "altitude": "Hoogte",
-  "ammenity": "Ammenity",
+  "amenity": "Amenity",
   "api-documentation": "API-documentatie",
   "attraction": "Attraction",
   "author": "Auteur",

--- a/web/src/lib/i18n/locales/pl.json
+++ b/web/src/lib/i18n/locales/pl.json
@@ -20,7 +20,7 @@
   "alphabetical": "Alfabetyczne",
   "already-account": "Czy masz już konto?",
   "altitude": "Wysokość",
-  "ammenity": "Ammenity",
+  "amenity": "Amenity",
   "api-documentation": "Dokumentacja API",
   "attraction": "Attraction",
   "author": "Autor",

--- a/web/src/lib/i18n/locales/pt.json
+++ b/web/src/lib/i18n/locales/pt.json
@@ -20,7 +20,7 @@
   "alphabetical": "Alfabético",
   "already-account": "Já tem uma conta?",
   "altitude": "Altitude",
-  "ammenity": "Ammenity",
+  "amenity": "Amenity",
   "api-documentation": "Documentação da API",
   "attraction": "Attraction",
   "author": "Author",

--- a/web/src/lib/i18n/locales/ru.json
+++ b/web/src/lib/i18n/locales/ru.json
@@ -20,7 +20,7 @@
   "alphabetical": "По алфавиту",
   "already-account": "Уже есть аккаунт?",
   "altitude": "Высота",
-  "ammenity": "Ammenity",
+  "amenity": "Amenity",
   "api-documentation": "Документация API",
   "attraction": "Attraction",
   "author": "Автор",

--- a/web/src/lib/i18n/locales/zh.json
+++ b/web/src/lib/i18n/locales/zh.json
@@ -20,7 +20,7 @@
   "alphabetical": "字母",
   "already-account": "已注册账户？",
   "altitude": "海拔",
-  "ammenity": "友好性",
+  "amenity": "友好性",
   "api-documentation": "API 文档",
   "attraction": "景点",
   "author": "作者",

--- a/web/src/lib/vendor/maplibre-layer-manager/layers.ts
+++ b/web/src/lib/vendor/maplibre-layer-manager/layers.ts
@@ -521,7 +521,7 @@ export const defaultMapState: MapState = {
             hut: false,
             viewpoint: false,
         },
-        ammenity: {
+        amenity: {
             water: false,
             barrier: false,
             shelter: false,


### PR DESCRIPTION
I initially wanted to contribute by translating the last words to german via crowdin (Konjugation machts schwierig ohne Kontext...) and stumbled across "Ammenity". So to make it easier (and avoid repetition of that mistake) I fixed it in the i18n files.

To be honest I do not understand the usage in the `layers.ts` file but the mm spelling doesn't appear anywhere else so I replaced that as well. 