### PR TITLE
use gcc/cgo for db image

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,6 +62,11 @@ jobs:
         with:
           go-version: '1.22'
 
+      - name: Install build tools (CGO + ARM64 Cross-Compiler)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential gcc-aarch64-linux-gnu
+
       # 2. Log in to Docker Hub
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -80,8 +85,8 @@ jobs:
         run: |
           # Build db image
           cd db
-          env GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -o pocketbase_arm64
-          env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o pocketbase_amd64
+          env GOOS=linux GOARCH=arm64 CGO_ENABLED=1 CC=aarch64-linux-gnu-gcc go build -o pocketbase_arm64
+          env GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build -o pocketbase_amd64          
           cd ..
           docker buildx build db/ --no-cache -t flomp/wanderer-db:$VERSION -t flomp/wanderer-db:latest --platform=linux/amd64,linux/arm64 --push
 

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,6 +1,11 @@
-FROM alpine:3.19
+FROM debian:bookworm-slim
 
 WORKDIR /
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       curl \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY migrations ./migrations
 COPY templates ./templates


### PR DESCRIPTION
Hi,

As mentioned in the official PocketBase documentation and blog posts, PocketBase/SQLite provides better performance with GCC (CGO_ENABLED). It's not a significant improvement, but it's worth using.