### PR TITLE
Add root CAs to db container

### DIFF
--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -42,6 +42,7 @@ FROM scratch
 WORKDIR /
 
 COPY --from=build /app/pocketbase /pocketbase
+COPY --from=build /etc/ssl/certs /etc/ssl/certs
 COPY --from=download-env /tmp/curl /curl
 COPY migrations ./migrations
 COPY templates ./templates


### PR DESCRIPTION
With the recent container image hardening, the containers no longer have any root CAs. As a result, pocketbase can no longer pull ActivityPub users from other sites.

This PR simply copies the SSL certs from the build container to the final image.

Fixes #752 