### PR TITLE
v0.18.4 Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@
 - Creating more than 29 lists does no longer prevent lists from loading
 - Fixes a bug that caused the GPS data to be removed from summit logs after editing
 - Fixes an issue that caused an infinite loop when creating a list with federation being active
+- Fixes an issue where bicycle routing options were incorrectly applied to car routing, and vice versa
+- Fixes an issue where filtering by multiple categories did not work as expected
+- Fixes imported tracks being marked private despite public-by-default settings
 
 ## Features
 - Trails can now be added to multiple lists at once
-
+- ActivityPub: External user access now requires authentication (401)
+  
 ## Translation
 -  Adds Norwegian translation (thanks @palhaland)
 

--- a/docs/src/content/docs/changelog.md
+++ b/docs/src/content/docs/changelog.md
@@ -8,10 +8,14 @@ description: What changed in the last patch?
 - Creating more than 29 lists does no longer prevent lists from loading
 - Fixes a bug that caused the GPS data to be removed from summit logs after editing
 - Fixes an issue that caused an infinite loop when creating a list with federation being active
+- Fixes an issue where bicycle routing options were incorrectly applied to car routing, and vice versa
+- Fixes an issue where filtering by multiple categories did not work as expected
+- Fixes imported tracks being marked private despite public-by-default settings
 
 ### Features
 - Trails can now be added to multiple lists at once
-
+- ActivityPub: External user access now requires authentication (401)
+  
 ### Translation
 -  Adds Norwegian translation (thanks @palhaland)
 


### PR DESCRIPTION
## v0.18.4
### Bug fixes
- Tags can now properly be removed from trails
- Creating more than 29 lists does no longer prevent lists from loading
- Fixes a bug that caused the GPS data to be removed from summit logs after editing
- Fixes an issue that caused an infinite loop when creating a list with federation being active

### Features
- Trails can now be added to multiple lists at once

### Translation
-  Adds Norwegian translation (thanks @palhaland)