### PR TITLE
fix trail upload for users with default privacy settings

### DIFF
--- a/web/src/routes/api/v1/trail/upload/+server.ts
+++ b/web/src/routes/api/v1/trail/upload/+server.ts
@@ -46,7 +46,7 @@ export async function PUT(event: RequestEvent) {
             trail.location ??= location;
         }
 
-        trail.public = event.locals.settings?.privacy?.trails == "public"
+        trail.public = event.locals.settings.privacy?.trails == "public"
 
         // const log = new SummitLog(trail.date as string, {
         //     distance: trail.distance,


### PR DESCRIPTION
Hi,

For new users, the privacy settings are missing (the db field is empty). In this case, the trail upload from the settings page will fail.