### PR TITLE
Only build amd64 image for dev release

### DIFF
--- a/.github/workflows/release_dev.yaml
+++ b/.github/workflows/release_dev.yaml
@@ -42,5 +42,5 @@ jobs:
 
       - name: Build Docker Images
         run: |
-          docker buildx build db/ --no-cache -t ghcr.io/open-wanderer/wanderer-db:dev --platform=linux/amd64,linux/arm64 --push
-          docker buildx build web/ --no-cache -t ghcr.io/open-wanderer/wanderer-web:dev --platform=linux/amd64,linux/arm64 --push
+          docker buildx build db/ --no-cache -t ghcr.io/open-wanderer/wanderer-db:dev --push
+          docker buildx build web/ --no-cache -t ghcr.io/open-wanderer/wanderer-web:dev --push


### PR DESCRIPTION
Removed platform specification from Docker build commands.

This might speed up builds.