### PR TITLE
fix CVE-2022-39299 (bump xmldom)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -28,7 +28,7 @@
         "@turf/distance": "^7.3.3",
         "@types/chart.js": "^4.0.1",
         "@types/three": "^0.182.0",
-        "@types/xmldom": "^0.1.34",
+        "@xmldom/xmldom": "^0.8.11",
         "activitypub-types": "^1.1.0",
         "autoprefixer": "^10.4.24",
         "canvas-confetti": "^1.9.4",
@@ -56,7 +56,6 @@
         "svelte-i18n": "^4.0.0",
         "three": "^0.182.0",
         "vitest": "^1.6.1",
-        "xmldom": "^0.6.0",
         "zod": "^3.24.1"
       },
       "devDependencies": {
@@ -2249,12 +2248,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/xmldom": {
-      "version": "0.1.34",
-      "resolved": "https://registry.npmjs.org/@types/xmldom/-/xmldom-0.1.34.tgz",
-      "integrity": "sha512-7eZFfxI9XHYjJJuugddV6N5YNeXgQE1lArWOcd1eCOKWb/FGs5SIjacSYuEJuwhsGS3gy4RuZ5EUIcqYscuPDA==",
-      "license": "MIT"
-    },
     "node_modules/@vitest/expect": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
@@ -2338,6 +2331,15 @@
       "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.69.tgz",
       "integrity": "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.11",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
+      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/acorn": {
       "version": "8.15.0",
@@ -6471,15 +6473,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4.0"
-      }
-    },
-    "node_modules/xmldom": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
-      "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/y18n": {

--- a/web/package.json
+++ b/web/package.json
@@ -49,7 +49,7 @@
     "@turf/distance": "^7.3.3",
     "@types/chart.js": "^4.0.1",
     "@types/three": "^0.182.0",
-    "@types/xmldom": "^0.1.34",
+    "@xmldom/xmldom": "^0.8.11",
     "activitypub-types": "^1.1.0",
     "autoprefixer": "^10.4.24",
     "canvas-confetti": "^1.9.4",
@@ -77,7 +77,6 @@
     "svelte-i18n": "^4.0.0",
     "three": "^0.182.0",
     "vitest": "^1.6.1",
-    "xmldom": "^0.6.0",
     "zod": "^3.24.1"
   }
 }

--- a/web/src/lib/util/gpx_util.ts
+++ b/web/src/lib/util/gpx_util.ts
@@ -11,7 +11,7 @@ import EasyFit from "$lib/vendor/easy-fit/easy-fit";
 import type { Feature, FeatureCollection, GeoJSON, GeoJsonProperties, Position } from 'geojson';
 import JSZip from "jszip";
 import type { AuthRecord } from "pocketbase";
-import * as xmldom from 'xmldom';
+import { DOMParser as XMLDOMParser } from "@xmldom/xmldom";
 import { bbox, splitMultiLineStringToLineStrings } from "./geojson_util";
 import { trails_show } from "$lib/stores/trail_store";
 import { handleFromRecordWithIRI } from "./activitypub_util";
@@ -161,7 +161,7 @@ export async function fromFile(file: File | Blob) {
 }
 
 export function fromKML(kmlData: string) {
-    const parser = browser ? new DOMParser() : new xmldom.DOMParser();
+    const parser = browser ? new DOMParser() : new XMLDOMParser();
     const nodes = parser.parseFromString(kmlData, "text/xml")
     const geojson = kml(nodes) as Feature | FeatureCollection
 
@@ -178,7 +178,7 @@ export async function fromKMZ(kmzData: ArrayBuffer) {
 }
 
 export function fromTCX(tcxData: string) {
-    const parser = browser ? new DOMParser() : new xmldom.DOMParser();
+    const parser = browser ? new DOMParser() : new XMLDOMParser();
     const nodes = parser.parseFromString(tcxData, "text/xml")
     const geojson = tcx(nodes) as Feature | FeatureCollection
 


### PR DESCRIPTION
fix CVE-2022-39299 (see gh security reports)