### PR TITLE
skip elevation correction if no valid height information returned by valhalla

### DIFF
--- a/web/src/lib/models/gpx/gpx.ts
+++ b/web/src/lib/models/gpx/gpx.ts
@@ -195,6 +195,12 @@ export default class GPX {
     }
 
     const heightResponse: ValhallaHeightResponse = await r2.json()
+    const heights = heightResponse.height ?? [];
+    const finiteHeights = heights.filter((height) => Number.isFinite(height)).length;
+
+    if (heights.length > 0 && finiteHeights === 0) {
+      return;
+    }
 
     let heightIndex = 0;
     for (const track of this.trk ?? []) {


### PR DESCRIPTION
During GPX upload, Valhalla intermittently returns only null values for height requests. In this case, we now skip the elevation correction process and retain the original GPX elevation values, rather than importing the track with 0 elevation gain/loss.