### PR TITLE
Allow OpenGraph for index

### DIFF
--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -148,6 +148,7 @@
 
 <svelte:head>
     <title>Home | wanderer</title>
+    <meta property="og:image" content="/og-image.png" />
 </svelte:head>
 
 <svelte:window onscroll={onScroll} />


### PR DESCRIPTION
This will allow to setup an open graph image for the main page for example by adding a bind to docker compose and place an image there:

```
 volumes:
[...]
      - ./data/og-image.png:/app/build/client/og-image.png 
```

If no image/bind is set the behavior is like before (no open graph image).

Other segments like Tracks are not affected