### PR TITLE
feat: meilisearch bounding box intersection and map filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Additional CSRF/SSRF protections and rate limiting have been implemented for ActivityPub and outbound network calls. (PR #930)
 
 ## Features
+- Tiered map clustering and polyline filtering: The world map now uses zoom-dependent thresholds to manage performance while maintaining transparency. Small trails are automatically clustered at lower zoom levels, while larger routes are shown as detailed polylines. These thresholds and visibility limits are fully configurable via new environment variables (`PUBLIC_MAP_*_ZOOM_THRESHOLD` and `PUBLIC_MAP_*_DIAGONAL_LIMIT`).
 - Hammerhead integration added, including synchronisation of planned and completed tours, and manual trail sending. (PR #628)
 - The federation has been significantly expanded and refactored to provide more robust remote content synchronisation and local caching for remote trails and lists. (PR #930)
 - Trails can now be explicitly marked as completed. (PR #920)
@@ -50,7 +51,6 @@
 
 ## Maintenance
 - Meilisearch, PocketBase, Go, web/docs dependencies, CI actions, and Docker build setup updated.
-
 
 # v0.18.5
 ## Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# [Unreleased]
+
+## Features
+- Tiered map clustering and polyline filtering: The world map now uses zoom-dependent thresholds to manage performance while maintaining transparency. Small trails are automatically clustered at lower zoom levels, while larger routes are shown as detailed polylines. These thresholds and visibility limits are fully configurable via new environment variables (`PUBLIC_MAP_*_ZOOM_THRESHOLD` and `PUBLIC_MAP_*_DIAGONAL_LIMIT`).
+
 # v0.19.0
 
 ## Breaking Changes
@@ -14,7 +19,6 @@
 - Additional CSRF/SSRF protections and rate limiting have been implemented for ActivityPub and outbound network calls. (PR #930)
 
 ## Features
-- Tiered map clustering and polyline filtering: The world map now uses zoom-dependent thresholds to manage performance while maintaining transparency. Small trails are automatically clustered at lower zoom levels, while larger routes are shown as detailed polylines. These thresholds and visibility limits are fully configurable via new environment variables (`PUBLIC_MAP_*_ZOOM_THRESHOLD` and `PUBLIC_MAP_*_DIAGONAL_LIMIT`).
 - Hammerhead integration added, including synchronisation of planned and completed tours, and manual trail sending. (PR #628)
 - The federation has been significantly expanded and refactored to provide more robust remote content synchronisation and local caching for remote trails and lists. (PR #930)
 - Trails can now be explicitly marked as completed. (PR #920)

--- a/db/main.go
+++ b/db/main.go
@@ -253,7 +253,7 @@ func initMeilisearchConfig(client meilisearch.ServiceManager) {
 			FilterableAttributes: []string{
 				"_geo", "author", "category", "completed", "date", "difficulty",
 				"distance", "elevation_gain", "elevation_loss", "likes", "public",
-				"shares", "tags",
+				"shares", "tags", "min_lat", "max_lat", "min_lon", "max_lon", "bounding_box_diagonal",
 			},
 			SortableAttributes: []string{
 				"author", "created", "date", "difficulty", "distance",

--- a/db/main.go
+++ b/db/main.go
@@ -251,7 +251,7 @@ func initMeilisearchConfig(client meilisearch.ServiceManager) {
 		"trails": {
 			SearchableAttributes: []string{"author_name", "name", "description", "location", "tags"},
 			FilterableAttributes: []string{
-				"_geo", "author", "category", "completed", "date", "difficulty",
+				"id", "_geo", "author", "category", "completed", "date", "difficulty",
 				"distance", "elevation_gain", "elevation_loss", "likes", "public",
 				"shares", "tags", "min_lat", "max_lat", "min_lon", "max_lon", "bounding_box_diagonal",
 			},

--- a/db/migrations/1776510000_update_meilisearch_bounds.go
+++ b/db/migrations/1776510000_update_meilisearch_bounds.go
@@ -1,0 +1,55 @@
+package migrations
+
+import (
+	"os"
+	"pocketbase/util"
+
+	"github.com/meilisearch/meilisearch-go"
+	"github.com/pocketbase/pocketbase/core"
+	m "github.com/pocketbase/pocketbase/migrations"
+)
+
+func init() {
+	client := meilisearch.New(os.Getenv("MEILI_URL"), meilisearch.WithAPIKey(os.Getenv("MEILI_MASTER_KEY")))
+
+	m.Register(func(app core.App) error {
+		_, err := client.Index("trails").UpdateFilterableAttributes(&[]any{
+			"_geo", "author", "category", "completed", "date", "difficulty", "distance", "elevation_gain", "elevation_loss", "public", "shares", "tags", "likes", "min_lat", "max_lat", "min_lon", "max_lon", "bounding_box_diagonal",
+		})
+		if err != nil {
+			return err
+		}
+
+		// Re-index all trails to populate the new bounding box and diagonal fields
+		const pageSize int64 = 50
+		var page int64 = 0
+
+		for {
+			trails := []*core.Record{}
+			err := app.RecordQuery("trails").
+				Limit(pageSize).
+				Offset(page * pageSize).
+				All(&trails)
+			if err != nil {
+				return err
+			}
+			if len(trails) == 0 {
+				break
+			}
+
+			if err := util.IndexTrails(app, trails, client); err != nil {
+				return err
+			}
+
+			page++
+		}
+
+		return nil
+	}, func(app core.App) error {
+		_, err := client.Index("trails").UpdateFilterableAttributes(&[]any{
+			"_geo", "author", "category", "completed", "date", "difficulty", "distance", "elevation_gain", "elevation_loss", "public", "shares", "tags", "likes",
+		})
+
+		return err
+	})
+}

--- a/db/util/meilisearch.go
+++ b/db/util/meilisearch.go
@@ -41,9 +41,10 @@ func documentFromTrailRecord(app core.App, r *core.Record, author *core.Record, 
 		category = trailCategory.GetString("name")
 	}
 
-	polyline, err := getPolyline(app, r)
+	polyline, bounds, err := getPolyline(app, r)
 	if err != nil {
 		polyline = ""
+		bounds = [4]float64{r.GetFloat("lat"), r.GetFloat("lat"), r.GetFloat("lon"), r.GetFloat("lon")}
 	}
 
 	domain := ""
@@ -51,30 +52,37 @@ func documentFromTrailRecord(app core.App, r *core.Record, author *core.Record, 
 		domain = author.GetString("domain")
 	}
 
+	diagonal := HaversineDistance(bounds[0], bounds[2], bounds[1], bounds[3])
+
 	document := map[string]any{
-		"id":             r.Id,
-		"author":         author.Id,
-		"author_name":    author.GetString("preferred_username"),
-		"author_avatar":  author.GetString("icon"),
-		"name":           r.GetString("name"),
-		"description":    r.GetString("description"),
-		"location":       r.GetString("location"),
-		"distance":       r.GetFloat("distance"),
-		"elevation_gain": r.GetFloat("elevation_gain"),
-		"elevation_loss": r.GetFloat("elevation_loss"),
-		"duration":       r.GetFloat("duration"),
-		"difficulty":     difficultyToNumber(r.GetString("difficulty")),
-		"category":       category,
-		"completed":      r.GetBool("completed"),
-		"date":           r.GetDateTime("date").Time().Unix(),
-		"created":        r.GetDateTime("created").Time().Unix(),
-		"public":         r.GetBool("public"),
-		"thumbnail":      thumbnail,
-		"gpx":            r.GetString("gpx"),
-		"tags":           tags,
-		"polyline":       polyline,
-		"domain":         domain,
-		"iri":            r.GetString("iri"),
+		"id":                    r.Id,
+		"author":                author.Id,
+		"author_name":           author.GetString("preferred_username"),
+		"author_avatar":         author.GetString("icon"),
+		"name":                  r.GetString("name"),
+		"description":           r.GetString("description"),
+		"location":              r.GetString("location"),
+		"distance":              r.GetFloat("distance"),
+		"elevation_gain":        r.GetFloat("elevation_gain"),
+		"elevation_loss":        r.GetFloat("elevation_loss"),
+		"duration":              r.GetFloat("duration"),
+		"difficulty":            difficultyToNumber(r.GetString("difficulty")),
+		"category":              category,
+		"completed":             r.GetBool("completed"),
+		"date":                  r.GetDateTime("date").Time().Unix(),
+		"created":               r.GetDateTime("created").Time().Unix(),
+		"public":                r.GetBool("public"),
+		"thumbnail":             thumbnail,
+		"gpx":                   r.GetString("gpx"),
+		"tags":                  tags,
+		"polyline":              polyline,
+		"domain":                domain,
+		"iri":                   r.GetString("iri"),
+		"min_lat":               bounds[0],
+		"max_lat":               bounds[1],
+		"min_lon":               bounds[2],
+		"max_lon":               bounds[3],
+		"bounding_box_diagonal": diagonal,
 		"_geo": map[string]float64{
 			"lat": r.GetFloat("lat"),
 			"lng": r.GetFloat("lon"),
@@ -128,44 +136,88 @@ func difficultyToNumber(difficulty string) int32 {
 	return 0
 }
 
-func getPolyline(app core.App, r *core.Record) (string, error) {
+func getPolyline(app core.App, r *core.Record) (string, [4]float64, error) {
+	lat := r.GetFloat("lat")
+	lon := r.GetFloat("lon")
+	defaultBounds := [4]float64{lat, lat, lon, lon}
+
 	gpxPath := r.GetString("gpx")
 	if len(gpxPath) == 0 {
-		return "", nil
+		return "", defaultBounds, nil
 	}
 	avatarKey := r.BaseFilesPath() + "/" + gpxPath
 	fsys, err := app.NewFilesystem()
 	if err != nil {
-		return "", err
+		return "", defaultBounds, err
 	}
 	defer fsys.Close()
 
 	gpxFile, err := fsys.GetReader(avatarKey)
 	if err != nil {
-		return "", err
+		return "", defaultBounds, err
 	}
 	defer gpxFile.Close()
 
 	content := new(bytes.Buffer)
 	_, err = io.Copy(content, gpxFile)
 	if err != nil {
-		return "", err
+		return "", defaultBounds, err
 	}
 	gpxData, err := gpx.Parse(content)
 	if err != nil {
-		return "", err
+		return "", defaultBounds, err
 	}
 
 	gpxData.SimplifyTracks(50)
-	coordinates := make([][]float64, 4)
+	coordinates := make([][]float64, 0)
+	minLat, maxLat, minLon, maxLon := 90.0, -90.0, 180.0, -180.0
+	hasPoints := false
+
 	for _, trk := range gpxData.Tracks {
 		for _, seg := range trk.Segments {
 			for _, pt := range seg.Points {
 				coordinates = append(coordinates, []float64{pt.Latitude, pt.Longitude})
+				if pt.Latitude < minLat {
+					minLat = pt.Latitude
+				}
+				if pt.Latitude > maxLat {
+					maxLat = pt.Latitude
+				}
+				if pt.Longitude < minLon {
+					minLon = pt.Longitude
+				}
+				if pt.Longitude > maxLon {
+					maxLon = pt.Longitude
+				}
+				hasPoints = true
 			}
 		}
 	}
-	return string(polyline.EncodeCoords(coordinates)), nil
+
+	for _, rte := range gpxData.Routes {
+		for _, pt := range rte.Points {
+			coordinates = append(coordinates, []float64{pt.Latitude, pt.Longitude})
+			if pt.Latitude < minLat {
+				minLat = pt.Latitude
+			}
+			if pt.Latitude > maxLat {
+				maxLat = pt.Latitude
+			}
+			if pt.Longitude < minLon {
+				minLon = pt.Longitude
+			}
+			if pt.Longitude > maxLon {
+				maxLon = pt.Longitude
+			}
+			hasPoints = true
+		}
+	}
+
+	if !hasPoints {
+		return "", defaultBounds, nil
+	}
+
+	return string(polyline.EncodeCoords(coordinates)), [4]float64{minLat, maxLat, minLon, maxLon}, nil
 }
 
 func documentFromListRecord(r *core.Record, author *core.Record, includeShares bool) (map[string]any, error) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,12 @@ services:
       OVERPASS_API_URL: https://overpass-api.de
       VALHALLA_URL: https://valhalla1.openstreetmap.de
       NOMINATIM_URL: https://nominatim.openstreetmap.org
+      PUBLIC_MAP_LOW_ZOOM_THRESHOLD: 8
+      PUBLIC_MAP_LOW_ZOOM_DIAGONAL_LIMIT: 25000
+      PUBLIC_MAP_MEDIUM_ZOOM_THRESHOLD: 10
+      PUBLIC_MAP_MEDIUM_ZOOM_DIAGONAL_LIMIT: 10000
+      PUBLIC_MAP_HIGH_ZOOM_THRESHOLD: 12
+      PUBLIC_MAP_HIGH_ZOOM_DIAGONAL_LIMIT: 5000
     volumes:
       - ./data/uploads:/app/uploads
       # - ./data/about.md:/app/build/client/md/about.md

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -55,6 +55,12 @@ services:
       OVERPASS_API_URL: https://overpass-api.de
       VALHALLA_URL: https://valhalla1.openstreetmap.de
       NOMINATIM_URL: https://nominatim.openstreetmap.org
+      PUBLIC_MAP_LOW_ZOOM_THRESHOLD: 8
+      PUBLIC_MAP_LOW_ZOOM_DIAGONAL_LIMIT: 25000
+      PUBLIC_MAP_MEDIUM_ZOOM_THRESHOLD: 10
+      PUBLIC_MAP_MEDIUM_ZOOM_DIAGONAL_LIMIT: 10000
+      PUBLIC_MAP_HIGH_ZOOM_THRESHOLD: 12
+      PUBLIC_MAP_HIGH_ZOOM_DIAGONAL_LIMIT: 5000
     volumes:
       - uploads:/app/uploads
       # - ./data/about.md:/app/build/client/md/about.md

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -55,6 +55,12 @@ services:
       OVERPASS_API_URL: https://overpass-api.de
       VALHALLA_URL: https://valhalla1.openstreetmap.de
       NOMINATIM_URL: https://nominatim.openstreetmap.org
+      PUBLIC_MAP_LOW_ZOOM_THRESHOLD: 8
+      PUBLIC_MAP_LOW_ZOOM_DIAGONAL_LIMIT: 25000
+      PUBLIC_MAP_MEDIUM_ZOOM_THRESHOLD: 10
+      PUBLIC_MAP_MEDIUM_ZOOM_DIAGONAL_LIMIT: 10000
+      PUBLIC_MAP_HIGH_ZOOM_THRESHOLD: 12
+      PUBLIC_MAP_HIGH_ZOOM_DIAGONAL_LIMIT: 5000
     volumes:
       - uploads:/app/uploads
       # - ./data/about.md:/app/build/client/md/about.md

--- a/docs/src/content/docs/run/environment-configuration.md
+++ b/docs/src/content/docs/run/environment-configuration.md
@@ -43,6 +43,12 @@ Since we use an unmodified installation of meilisearch you can use all variables
 | PUBLIC_POCKETBASE_URL   | IP or hostname (including the port) of your pocketbase instance                  | http://db:8090                      |
 | PUBLIC_DISABLE_SIGNUP   | Disables signup option for new users                                             | false                               |
 | PUBLIC_PRIVATE_INSTANCE | Setting this to true will block visitors from viewing content without an account | false                               |
+| PUBLIC_MAP_LOW_ZOOM_THRESHOLD | Zoom level below which small trails are clustered and only very large trails are shown | 8 |
+| PUBLIC_MAP_LOW_ZOOM_DIAGONAL_LIMIT | Minimum diagonal distance (meters) for a trail to be shown as a path below the low zoom threshold | 25000 |
+| PUBLIC_MAP_MEDIUM_ZOOM_THRESHOLD | Zoom level below which medium-sized trails are clustered | 10 |
+| PUBLIC_MAP_MEDIUM_ZOOM_DIAGONAL_LIMIT | Minimum diagonal distance (meters) for a trail to be shown as a path below the medium zoom threshold | 10000 |
+| PUBLIC_MAP_HIGH_ZOOM_THRESHOLD | Zoom level below which small trails are clustered | 12 |
+| PUBLIC_MAP_HIGH_ZOOM_DIAGONAL_LIMIT | Minimum diagonal distance (meters) for a trail to be shown as a path below the high zoom threshold | 5000 |
 | UPLOAD_FOLDER           | Folder from which <span class="-tracking-[0.075em]">wanderer</span> auto-uploads trails                                   | /app/uploads                        |
 | UPLOAD_USER             | Username for the account with which <span class="-tracking-[0.075em]">wanderer</span> auto-uploads trails                 |                                     |
 | UPLOAD_PASSWORD         | Password for the account with which <span class="-tracking-[0.075em]">wanderer</span> auto-uploads trails                 |                                     |

--- a/web/src/lib/components/base/text_field.svelte
+++ b/web/src/lib/components/base/text_field.svelte
@@ -11,7 +11,7 @@
         error?: string | string[] | null;
         icon?: string;
         extraClasses?: string;
-        type?: "text" | "password" | "search";
+        type?: "text" | "password" | "search" | "number";
         autocomplete?: "on" | "off";
         onchange?: ChangeEventHandler<HTMLInputElement>;
         oninput?: FormEventHandler<HTMLInputElement>;

--- a/web/src/lib/components/trail/map_with_elevation_maplibre.svelte
+++ b/web/src/lib/components/trail/map_with_elevation_maplibre.svelte
@@ -4,6 +4,13 @@
     import directionCaret from "$lib/assets/svgs/caret-right-solid.svg";
     import GPX from "$lib/models/gpx/gpx";
     import type { Trail } from "$lib/models/trail";
+    import {
+        MAP_HIGH_ZOOM_DIAGONAL_LIMIT,
+        MAP_LOW_ZOOM_DIAGONAL_LIMIT,
+        MAP_LOW_ZOOM_THRESHOLD,
+        MAP_MEDIUM_ZOOM_DIAGONAL_LIMIT,
+        MAP_MEDIUM_ZOOM_THRESHOLD,
+    } from "$lib/stores/trail_store";
     import type { Waypoint } from "$lib/models/waypoint";
     import { theme } from "$lib/stores/theme_store";
     import { findStartAndEndPoints } from "$lib/util/geojson_util";
@@ -135,9 +142,14 @@
 
     let clusterPopup: M.Popup | null = null;
 
-    let [data, clusterData, previewData] = $derived(getData(trails));
+    let [gpxDataMap, clusterData, previewData] = $derived(getData(trails));
     $effect(() => {
-        if (data && map && mapLoaded) {
+        // Track dependencies for Svelte 5
+        gpxDataMap;
+        clusterData;
+        previewData;
+
+        if (map && mapLoaded) {
             untrack(() => initMap(map?.loaded() ?? false));
         }
     });
@@ -189,7 +201,11 @@
 
     function getData(
         trails: Trail[],
-    ): [FeatureCollection[], FeatureCollection, FeatureCollection] {
+    ): [
+        Record<string, FeatureCollection>,
+        FeatureCollection,
+        FeatureCollection,
+    ] {
         let clusterData: FeatureCollection = {
             type: "FeatureCollection",
             features: [],
@@ -198,16 +214,30 @@
             type: "FeatureCollection",
             features: [],
         };
-        let r: FeatureCollection[] = [];
+        let gpxDataMap: Record<string, FeatureCollection> = {};
 
-        trails.forEach((t, i) => {
-            if (t.expand?.gpx) {
-                r.push(t.expand.gpx.toGeoJSON());
-            } else if (t.expand?.gpx_data) {
-                r.push(GPX.parse(t.expand.gpx_data).toGeoJSON());
+        trails.forEach((t) => {
+            if (t.id) {
+                let fc: FeatureCollection | null = null;
+                if (t.expand?.gpx) {
+                    fc = t.expand.gpx.toGeoJSON();
+                } else if (t.expand?.gpx_data) {
+                    fc = GPX.parse(t.expand.gpx_data).toGeoJSON();
+                }
+
+                if (fc) {
+                    fc.features.forEach((f) => {
+                        if (f.properties) {
+                            f.properties.bounding_box_diagonal =
+                                t.bounding_box_diagonal;
+                        }
+                    });
+                    gpxDataMap[t.id] = fc;
+                }
             }
+
             if (clusterTrails) {
-                if (t.lat !== null && t.lon !== null) {
+                if (t.lat !== undefined && t.lon !== undefined) {
                     clusterData.features.push({
                         id: t.id,
                         type: "Feature",
@@ -228,6 +258,7 @@
                         type: "Feature",
                         properties: {
                             trail: t.id,
+                            bounding_box_diagonal: t.bounding_box_diagonal,
                             color: trailColors[
                                 hashStringToIndex(
                                     t.id ?? "",
@@ -244,7 +275,7 @@
             }
         });
 
-        return [r, clusterData, previewData];
+        return [gpxDataMap, clusterData, previewData];
     }
 
     function initMap(mapLoaded: boolean) {
@@ -253,15 +284,19 @@
         }
 
         refreshElevationProfile();
-        if (showElevation && data.length && activeTrail !== null) {
+        if (
+            showElevation &&
+            Object.keys(gpxDataMap).length &&
+            activeTrail !== null
+        ) {
             epc?.showProfile();
         } else {
             epc?.hideProfile();
         }
 
-        trails.forEach((t, i) => {
+        trails.forEach((t) => {
             const layerId = t.id!;
-            addTrailLayer(t, layerId, i, data[i]);
+            addTrailLayer(t, layerId, 0, gpxDataMap[layerId]);
         });
         if (clusterTrails) {
             addClusterLayer(clusterData);
@@ -279,18 +314,26 @@
             }
         });
 
-        if (
-            !drawing &&
-            fitBounds !== "off" &&
-            data.some((d) => d.bbox !== undefined)
-        ) {
-            if (activeTrail !== null && trails[activeTrail] && mapLoaded) {
+        if (!drawing && fitBounds !== "off") {
+            const currentBboxes = Object.values(gpxDataMap)
+                .map((d) => d.bbox)
+                .filter((b) => b !== undefined);
+
+            if (
+                activeTrail !== null &&
+                trails[activeTrail] &&
+                mapLoaded &&
+                gpxDataMap[trails[activeTrail].id!]
+            ) {
                 focusTrail(trails[activeTrail]);
-            } else {
+            } else if (currentBboxes.length > 0) {
                 flyToBounds();
             }
         } else if (drawing && activeTrail !== null && mapLoaded) {
-            addCaretLayer(data[activeTrail]);
+            const activeId = trails[activeTrail]?.id;
+            if (activeId && gpxDataMap[activeId]) {
+                addCaretLayer(gpxDataMap[activeId]);
+            }
         }
     }
 
@@ -314,8 +357,9 @@
     }
 
     export function refreshElevationProfile() {
-        if (activeTrail !== null && data[activeTrail]) {
-            epc?.setData(data[activeTrail]!, waypoints);
+        const activeId = activeTrail !== null ? trails[activeTrail]?.id : null;
+        if (activeId && gpxDataMap[activeId]) {
+            epc?.setData(gpxDataMap[activeId]!, waypoints);
         }
     }
 
@@ -325,7 +369,7 @@
             maxX = -Infinity,
             maxY = -Infinity;
 
-        for (const [xMin, yMin, xMax, yMax] of data
+        for (const [xMin, yMin, xMax, yMax] of Object.values(gpxDataMap)
             .filter((d) => d.bbox !== undefined)
             .map((d) => d.bbox!)) {
             minX = Math.min(minX, xMin);
@@ -347,9 +391,10 @@
     }
 
     function flyToBounds() {
+        const activeId = activeTrail !== null ? trails[activeTrail]?.id : null;
         const bounds =
-            activeTrail !== null && data[activeTrail]
-                ? (data[activeTrail].bbox as M.LngLatBoundsLike)
+            activeId && gpxDataMap[activeId]
+                ? (gpxDataMap[activeId].bbox as M.LngLatBoundsLike)
                 : getBounds();
 
         if (!bounds || !map) {
@@ -390,18 +435,33 @@
             trailColors[
                 clusterTrails
                     ? hashStringToIndex(id ?? "", trailColors.length)
-                    : 0
+                    : index % trailColors.length
             ],
             {
-                onEnter: (e) =>
-                    highlightTrail(id, trails[activeTrail ?? -1]?.id == id),
-
-                onLeave: (e) => unHighlightTrail(id),
-                onMouseUp: (e) => {
-                    activeTrail = trails.findIndex((t) => t.id == trail.id);
+                minZoom: clusterTrails ? clusterMinZoom : undefined,
+                tiers: {
+                    thresholds: [
+                        MAP_LOW_ZOOM_THRESHOLD,
+                        MAP_MEDIUM_ZOOM_THRESHOLD,
+                        clusterMinZoom,
+                    ],
+                    limits: [
+                        MAP_LOW_ZOOM_DIAGONAL_LIMIT,
+                        MAP_MEDIUM_ZOOM_DIAGONAL_LIMIT,
+                        MAP_HIGH_ZOOM_DIAGONAL_LIMIT,
+                    ],
                 },
-                onMouseMove: moveCrosshairToCursorPosition,
-                onMouseDown: (e) => handleDragStart(e, id),
+                listeners: {
+                    onEnter: (e) =>
+                        highlightTrail(id, trails[activeTrail ?? -1]?.id == id),
+
+                    onLeave: (e) => unHighlightTrail(id),
+                    onMouseUp: (e) => {
+                        activeTrail = trails.findIndex((t) => t.id == trail.id);
+                    },
+                    onMouseMove: moveCrosshairToCursorPosition,
+                    onMouseDown: (e) => handleDragStart(e, id),
+                },
             },
         );
 
@@ -420,14 +480,14 @@
             "clusters",
             new ClusterLayer(map, geojson, clusterMinZoom, {
                 thresholds: [
-                    Number(env.PUBLIC_MAP_LOW_ZOOM_THRESHOLD || 8),
-                    Number(env.PUBLIC_MAP_MEDIUM_ZOOM_THRESHOLD || 10),
-                    Number(env.PUBLIC_MAP_HIGH_ZOOM_THRESHOLD || 12),
+                    MAP_LOW_ZOOM_THRESHOLD,
+                    MAP_MEDIUM_ZOOM_THRESHOLD,
+                    clusterMinZoom,
                 ],
                 limits: [
-                    Number(env.PUBLIC_MAP_LOW_ZOOM_DIAGONAL_LIMIT || 25000),
-                    Number(env.PUBLIC_MAP_MEDIUM_ZOOM_DIAGONAL_LIMIT || 10000),
-                    Number(env.PUBLIC_MAP_HIGH_ZOOM_DIAGONAL_LIMIT || 5000),
+                    MAP_LOW_ZOOM_DIAGONAL_LIMIT,
+                    MAP_MEDIUM_ZOOM_DIAGONAL_LIMIT,
+                    MAP_HIGH_ZOOM_DIAGONAL_LIMIT,
                 ],
             }),
         );
@@ -440,18 +500,32 @@
         layerManager.addLayer(
             "preview",
             new PreviewLayer(map, geojson, clusterMinZoom, {
-                preview: {
-                    onEnter: (e) => {
-                        const trail = trails.find(
-                            (t) =>
-                                t.id ===
-                                (e as any).features[0].properties.trail,
-                        );
-                        if (!trail) return;
-                        highlightCluster(trail, e.lngLat);
-                    },
-                    onLeave: (e) => {
-                        // unHighlightCluster();
+                tiers: {
+                    thresholds: [
+                        MAP_LOW_ZOOM_THRESHOLD,
+                        MAP_MEDIUM_ZOOM_THRESHOLD,
+                        clusterMinZoom,
+                    ],
+                    limits: [
+                        MAP_LOW_ZOOM_DIAGONAL_LIMIT,
+                        MAP_MEDIUM_ZOOM_DIAGONAL_LIMIT,
+                        MAP_HIGH_ZOOM_DIAGONAL_LIMIT,
+                    ],
+                },
+                listeners: {
+                    preview: {
+                        onEnter: (e) => {
+                            const trail = trails.find(
+                                (t) =>
+                                    t.id ===
+                                    (e as any).features[0].properties.trail,
+                            );
+                            if (!trail) return;
+                            highlightCluster(trail, e.lngLat);
+                        },
+                        onLeave: (e) => {
+                            // unHighlightCluster();
+                        },
                     },
                 },
             }),
@@ -596,7 +670,7 @@
             if (
                 !drawing &&
                 fitBounds !== "off" &&
-                data.some((d) => d.bbox !== undefined)
+                Object.values(gpxDataMap).some((d) => d.bbox !== undefined)
             ) {
                 untrack(() => focusTrail(trails[activeTrail]));
             }
@@ -619,7 +693,9 @@
                 epc?.showProfile();
             }
             showWaypoints();
-            addCaretLayer(data[activeTrail]);
+            if (trail.id && gpxDataMap[trail.id]) {
+                addCaretLayer(gpxDataMap[trail.id]);
+            }
             flyToBounds();
         } catch (e) {
             console.warn(e);
@@ -666,10 +742,11 @@
         map.getCanvas().style.cursor = "inherit";
 
         if (activeTrail !== null && trails[activeTrail] && !clusterTrails) {
+            const activeId = trails[activeTrail].id;
             addStartEndMarkers(
                 trails[activeTrail],
-                trails[activeTrail].id,
-                data[activeTrail],
+                activeId,
+                activeId ? gpxDataMap[activeId] : null,
             );
         }
     }
@@ -826,6 +903,13 @@
             ...mapOptions,
         };
         map = new M.Map(finalMapOptions);
+
+        // Ensure we always have glyphs for symbol layers (like cluster counts)
+        map.on("styledata", () => {
+            if (map && !map.getStyle().glyphs) {
+                map.setGlyphs("https://tiles.openfreemap.org/fonts/{fontstack}/{range}.pbf");
+            }
+        });
 
         layerManager = new LayerManager(map);
 
@@ -1021,8 +1105,9 @@
 
         if (e.key == "m") {
             if (trails.length === 1) {
-                addTrailLayer(trails[0], trails[0].id!, 0, data[0]);
-                addCaretLayer(data[0]);
+                const trailId = trails[0].id!;
+                addTrailLayer(trails[0], trailId, 0, gpxDataMap[trailId]);
+                addCaretLayer(gpxDataMap[trailId]);
             }
         } else if (e.key == "p") {
             if (showElevation) {

--- a/web/src/lib/components/trail/map_with_elevation_maplibre.svelte
+++ b/web/src/lib/components/trail/map_with_elevation_maplibre.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { page } from "$app/state";
+    import { env } from '$env/dynamic/public';
     import directionCaret from "$lib/assets/svgs/caret-right-solid.svg";
     import GPX from "$lib/models/gpx/gpx";
     import type { Trail } from "$lib/models/trail";
@@ -49,6 +50,7 @@
         mapOptions?: Partial<M.MapOptions> | undefined;
         activeTrail?: number | null;
         clusterTrails?: boolean;
+        clusterMinZoom?: number;
         onsegmentdragend?: (data: {
             segment: number;
             event: M.MapMouseEvent;
@@ -88,6 +90,7 @@
         mapOptions = undefined,
         activeTrail = $bindable(0),
         clusterTrails = false,
+        clusterMinZoom = 10,
         onmarkerdragend,
         onsegmentdragend,
         onsegmentclick,
@@ -210,6 +213,7 @@
                         type: "Feature",
                         properties: {
                             trail: t.id,
+                            bounding_box_diagonal: t.bounding_box_diagonal,
                         },
                         geometry: {
                             type: "Point",
@@ -412,7 +416,21 @@
         if (!geojson || !map || !map.style) {
             return;
         }
-        layerManager.addLayer("clusters", new ClusterLayer(map, geojson));
+        layerManager.addLayer(
+            "clusters",
+            new ClusterLayer(map, geojson, clusterMinZoom, {
+                thresholds: [
+                    Number(env.PUBLIC_MAP_LOW_ZOOM_THRESHOLD || 8),
+                    Number(env.PUBLIC_MAP_MEDIUM_ZOOM_THRESHOLD || 10),
+                    Number(env.PUBLIC_MAP_HIGH_ZOOM_THRESHOLD || 12),
+                ],
+                limits: [
+                    Number(env.PUBLIC_MAP_LOW_ZOOM_DIAGONAL_LIMIT || 25000),
+                    Number(env.PUBLIC_MAP_MEDIUM_ZOOM_DIAGONAL_LIMIT || 10000),
+                    Number(env.PUBLIC_MAP_HIGH_ZOOM_DIAGONAL_LIMIT || 5000),
+                ],
+            }),
+        );
     }
 
     function addPreviewLayer(geojson: FeatureCollection) {
@@ -421,7 +439,7 @@
         }
         layerManager.addLayer(
             "preview",
-            new PreviewLayer(map, geojson, {
+            new PreviewLayer(map, geojson, clusterMinZoom, {
                 preview: {
                     onEnter: (e) => {
                         const trail = trails.find(

--- a/web/src/lib/i18n/locales/cs.json
+++ b/web/src/lib/i18n/locales/cs.json
@@ -264,6 +264,7 @@
   "make-one": "Vytvořte si vlastní!",
   "make-thumbnail": "Vytvořit náhled",
   "map": "Mapa",
+  "map-cluster-zoom-level": "Úroveň přiblížení pro seskupování tras (0-22)",
   "map-style": "Styl mapy",
   "mark-trail-as-completed": "",
   "mark-trail-as-completed-modal-text": "",

--- a/web/src/lib/i18n/locales/de.json
+++ b/web/src/lib/i18n/locales/de.json
@@ -284,6 +284,7 @@
   "make-one": "Neues erstellen!",
   "make-thumbnail": "Thumbnail festlegen",
   "map": "Karte",
+  "map-cluster-zoom-level": "Zoomstufe für die Gruppierung von Spuren (0-22)",
   "map-style": "Kartenstil",
   "mark-trail-as-completed": "Route als abgeschlossen markieren",
   "mark-trail-as-completed-modal-text": "Möchtest du diese Route als abgeschlossen markieren? Du kannst diesen Status jederzeit wieder ändern.",

--- a/web/src/lib/i18n/locales/de.json
+++ b/web/src/lib/i18n/locales/de.json
@@ -284,7 +284,7 @@
   "make-one": "Neues erstellen!",
   "make-thumbnail": "Thumbnail festlegen",
   "map": "Karte",
-  "map-cluster-zoom-level": "Zoomstufe für die Gruppierung von Spuren (0-22)",
+  "map-cluster-zoom-level": "Zoomstufe für die Gruppierung von Routen (0-22)",
   "map-style": "Kartenstil",
   "mark-trail-as-completed": "Route als abgeschlossen markieren",
   "mark-trail-as-completed-modal-text": "Möchtest du diese Route als abgeschlossen markieren? Du kannst diesen Status jederzeit wieder ändern.",

--- a/web/src/lib/i18n/locales/en.json
+++ b/web/src/lib/i18n/locales/en.json
@@ -284,6 +284,7 @@
   "make-one": "Make one!",
   "make-thumbnail": "Make thumbnail",
   "map": "Map",
+  "map-cluster-zoom-level": "Zoom level to start grouping tracks (0-22)",
   "map-style": "Map style",
   "mark-trail-as-completed": "Mark trail as completed",
   "mark-trail-as-completed-modal-text": "Would you like to mark this trail as completed? You can change this status again at any time.",

--- a/web/src/lib/i18n/locales/es.json
+++ b/web/src/lib/i18n/locales/es.json
@@ -264,6 +264,7 @@
   "make-one": "¡Crea uno!",
   "make-thumbnail": "Generar miniaturas",
   "map": "Mapa",
+  "map-cluster-zoom-level": "Nivel de zoom para agrupar pistas (0-22)",
   "map-style": "Estilo de mapa",
   "mark-trail-as-completed": "",
   "mark-trail-as-completed-modal-text": "",

--- a/web/src/lib/i18n/locales/eu.json
+++ b/web/src/lib/i18n/locales/eu.json
@@ -264,6 +264,7 @@
   "make-one": "Egin bat!",
   "make-thumbnail": "Egin iruditxoa",
   "map": "Mapa",
+  "map-cluster-zoom-level": "Zoom-maila pistak taldekatzeko (0-22)",
   "map-style": "Maparen estiloa",
   "mark-trail-as-completed": "",
   "mark-trail-as-completed-modal-text": "",

--- a/web/src/lib/i18n/locales/fr.json
+++ b/web/src/lib/i18n/locales/fr.json
@@ -264,6 +264,7 @@
   "make-one": "Faites-en un !",
   "make-thumbnail": "Créer une miniature",
   "map": "Carte",
+  "map-cluster-zoom-level": "Niveau de zoom pour le groupement des traces (0-22)",
   "map-style": "Style de carte",
   "mark-trail-as-completed": "",
   "mark-trail-as-completed-modal-text": "",

--- a/web/src/lib/i18n/locales/hu.json
+++ b/web/src/lib/i18n/locales/hu.json
@@ -264,6 +264,7 @@
   "make-one": "Készítsen egyet!",
   "make-thumbnail": "Készítsen miniatűrképet",
   "map": "Térkép",
+  "map-cluster-zoom-level": "Nagyítási szint a nyomvonalak csoportosításához (0-22)",
   "map-style": "Map style",
   "mark-trail-as-completed": "",
   "mark-trail-as-completed-modal-text": "",

--- a/web/src/lib/i18n/locales/it.json
+++ b/web/src/lib/i18n/locales/it.json
@@ -264,6 +264,7 @@
   "make-one": "Creane uno!",
   "make-thumbnail": "Imposta miniatura",
   "map": "Mappa",
+  "map-cluster-zoom-level": "Livello di zoom per il raggruppamento delle tracce (0-22)",
   "map-style": "Map style",
   "mark-trail-as-completed": "",
   "mark-trail-as-completed-modal-text": "",

--- a/web/src/lib/i18n/locales/nl.json
+++ b/web/src/lib/i18n/locales/nl.json
@@ -264,6 +264,7 @@
   "make-one": "Maak er een aan!",
   "make-thumbnail": "Miniatuur maken",
   "map": "Kaart",
+  "map-cluster-zoom-level": "Zoomniveau voor het groeperen van sporen (0-22)",
   "map-style": "Kaartstijl",
   "mark-trail-as-completed": "",
   "mark-trail-as-completed-modal-text": "",

--- a/web/src/lib/i18n/locales/no.json
+++ b/web/src/lib/i18n/locales/no.json
@@ -264,6 +264,7 @@
   "make-one": "Lag en!",
   "make-thumbnail": "Lag miniatyrbilde",
   "map": "Kart",
+  "map-cluster-zoom-level": "Zoomnivå for gruppering av spor (0-22)",
   "map-style": "Kartstil",
   "mark-trail-as-completed": "",
   "mark-trail-as-completed-modal-text": "",

--- a/web/src/lib/i18n/locales/pl.json
+++ b/web/src/lib/i18n/locales/pl.json
@@ -264,6 +264,7 @@
   "make-one": "Stwórz ją!",
   "make-thumbnail": "Zrób miniaturkę",
   "map": "Mapa",
+  "map-cluster-zoom-level": "Poziom powiększenia dla grupowania śladów (0-22)",
   "map-style": "Map style",
   "mark-trail-as-completed": "",
   "mark-trail-as-completed-modal-text": "",

--- a/web/src/lib/i18n/locales/pt.json
+++ b/web/src/lib/i18n/locales/pt.json
@@ -264,6 +264,7 @@
   "make-one": "Faz um!",
   "make-thumbnail": "Faça miniatura",
   "map": "Mapa",
+  "map-cluster-zoom-level": "Nível de zoom para agrupamento de trilhas (0-22)",
   "map-style": "Map style",
   "mark-trail-as-completed": "",
   "mark-trail-as-completed-modal-text": "",

--- a/web/src/lib/i18n/locales/ru.json
+++ b/web/src/lib/i18n/locales/ru.json
@@ -264,6 +264,7 @@
   "make-one": "Создайте!",
   "make-thumbnail": "Сделать миниатюру",
   "map": "Карта",
+  "map-cluster-zoom-level": "Уровень масштабирования для группировки треков (0-22)",
   "map-style": "Стиль карты",
   "mark-trail-as-completed": "",
   "mark-trail-as-completed-modal-text": "",

--- a/web/src/lib/i18n/locales/zh.json
+++ b/web/src/lib/i18n/locales/zh.json
@@ -264,6 +264,7 @@
   "make-one": "立刻注册！",
   "make-thumbnail": "生成缩略图",
   "map": "地图",
+  "map-cluster-zoom-level": "航迹分组的缩放级别 (0-22)",
   "map-style": "地图样式",
   "mark-trail-as-completed": "",
   "mark-trail-as-completed-modal-text": "",

--- a/web/src/lib/models/api/settings_schema.ts
+++ b/web/src/lib/models/api/settings_schema.ts
@@ -22,8 +22,10 @@ const SettingsCreateSchema = z.object({
         lists: z.enum(["public", "private"])
     }).optional().nullable(),
     notifications: z.record(z.enum(Object.values(NotificationType) as [string, ...string[]]), z.object({ web: z.boolean(), email: z.boolean() })).optional().nullable(),
-    behavior: z.object({ allowAutoGeolocate: z.boolean() }).optional().nullable(),
+    behavior: z.object({
+        allowAutoGeolocate: z.boolean(),
+        mapClusterMinZoom: z.coerce.number().optional()
+    }).optional().nullable(),
 }) satisfies ZodType<Settings>
-ZodType<Partial<Comment>>
 
 export { SettingsCreateSchema };

--- a/web/src/lib/models/settings.ts
+++ b/web/src/lib/models/settings.ts
@@ -57,6 +57,7 @@ class Settings {
 
 export type Behavior = {
     allowAutoGeolocate: boolean;
+    mapClusterMinZoom?: number;
 }
 
 

--- a/web/src/lib/models/trail.ts
+++ b/web/src/lib/models/trail.ts
@@ -34,6 +34,7 @@ class Trail {
     domain?: string;
     iri?: string;
     like_count: number;
+    bounding_box_diagonal?: number;
     expand?: {
         tags?: Tag[]
         category?: Category;
@@ -74,8 +75,9 @@ class Trail {
             comments?: Comment[],
             shares?: TrailShare[],
             tags?: Tag[],
-            description?: string
-            created?: string
+            description?: string,
+            created?: string,
+            bounding_box_diagonal?: number
         }
 
     ) {
@@ -96,6 +98,7 @@ class Trail {
         this.photos = params?.photos ?? [];
         this.tags = [];
         this.gpx = params?.gpx;
+        this.bounding_box_diagonal = params?.bounding_box_diagonal ?? 0;
         this.like_count = 0
         this.expand = {
             category: params?.category,
@@ -214,6 +217,7 @@ interface TrailSearchResult {
     domain?: string;
     iri?: string;
     gpx: string;
+    bounding_box_diagonal: number;
     _geo: {
         lat: number,
         lng: number
@@ -245,6 +249,7 @@ export const defaultTrailSearchAttributes = [
     "like_count",
     "shares",
     "iri",
+    "bounding_box_diagonal",
     "_geo",]
 
 

--- a/web/src/lib/stores/search_store.ts
+++ b/web/src/lib/stores/search_store.ts
@@ -99,7 +99,7 @@ export async function searchTrails(q: string, options: SearchParams): Promise<Hi
 
     const response: SearchResponse<TrailSearchResult> = await r.json();
 
-    return response.hits
+    return response.hits || []
 }
 
 export async function searchLocations(q: string, limit?: number, f: (url: RequestInfo | URL, config?: RequestInit) => Promise<Response> = fetch): Promise<Hits<LocationSearchResult>> {
@@ -196,6 +196,10 @@ export async function searchMulti(options: MultiSearchParams): Promise<MultiSear
     }
 
     const response: MultiSearchResponse<any> = await r.json();
+
+    if (!response.results) {
+        return [];
+    }
 
 
     if (locationQuery && locationQuery.q !== undefined && locationQuery.q !== null) {

--- a/web/src/lib/stores/trail_store.ts
+++ b/web/src/lib/stores/trail_store.ts
@@ -5,6 +5,7 @@ import type { Waypoint } from "$lib/models/waypoint";
 import { APIError } from "$lib/util/api_util";
 import { deepEqual } from "$lib/util/deep_util";
 import { getFileURL, objectToFormData } from "$lib/util/file_util";
+import { env } from '$env/dynamic/public';
 import * as M from "maplibre-gl";
 import type { Hits } from "meilisearch";
 import { type AuthRecord, type ListResult, type RecordModel } from "pocketbase";
@@ -93,7 +94,7 @@ export async function trails_search_filter(filter: TrailFilter, page: number = 1
 
 }
 
-export async function trails_search_bounding_box(northEast: M.LngLat, southWest: M.LngLat, filter: TrailFilter, page: number = 1, includePolyline: boolean = true) {
+export async function trails_search_bounding_box(northEast: M.LngLat, southWest: M.LngLat, filter: TrailFilter, page: number = 1, zoom: number = 11, polylineMinZoom: number = 10) {
     const user = get(currentUser)
 
     let filterText: string = "";
@@ -102,27 +103,88 @@ export async function trails_search_bounding_box(northEast: M.LngLat, southWest:
         filterText = buildFilterText(user, filter, false);
     }
 
-    let r = await fetch("/api/v1/search/trails", {
-        method: "POST",
-        body: JSON.stringify({
-            q: "",
-            options: {
-                filter: [
-                    `_geoBoundingBox([${northEast.lat}, ${northEast.lng}], [${southWest.lat}, ${southWest.lng}])`,
-                    filterText
-                ],
-                sort: [`${filter.sort}:${filter.sortOrder == "+" ? "asc" : "desc"}`,],
-                attributesToRetrieve: [...defaultTrailSearchAttributes, ...(includePolyline ? ["polyline"] : [])],
-                hitsPerPage: 500,
-                page: page
-            }
-        }),
-    });
-    const result: { page: number, totalPages: number, hits: Hits<TrailSearchResult> } = await r.json();
+    const includePolyline = zoom >= polylineMinZoom;
+    const lowZoomDiagonal = Number(env.PUBLIC_MAP_LOW_ZOOM_DIAGONAL_LIMIT || 25000);
+    const mediumZoomDiagonal = Number(env.PUBLIC_MAP_MEDIUM_ZOOM_DIAGONAL_LIMIT || 10000);
+    const highZoomDiagonal = Number(env.PUBLIC_MAP_HIGH_ZOOM_DIAGONAL_LIMIT || 5000);
 
-    if (result.hits.length == 0) {
+    const lowZoomThreshold = Number(env.PUBLIC_MAP_LOW_ZOOM_THRESHOLD || 8);
+    const mediumZoomThreshold = Number(env.PUBLIC_MAP_MEDIUM_ZOOM_THRESHOLD || 10);
+    const highZoomThreshold = Number(env.PUBLIC_MAP_HIGH_ZOOM_THRESHOLD || 12);
+
+    let diagonalFilter = "";
+    if (zoom < lowZoomThreshold) {
+        diagonalFilter = `bounding_box_diagonal > ${lowZoomDiagonal}`;
+    } else if (zoom < mediumZoomThreshold) {
+        diagonalFilter = `bounding_box_diagonal > ${mediumZoomDiagonal}`;
+    } else if (zoom < highZoomThreshold) {
+        diagonalFilter = `bounding_box_diagonal > ${highZoomDiagonal}`;
+    }
+
+    let lonFilter = `max_lon >= ${southWest.lng} AND min_lon <= ${northEast.lng}`;
+    if (southWest.lng > northEast.lng) {
+        lonFilter = `(max_lon >= ${southWest.lng} OR min_lon <= ${northEast.lng})`;
+    }
+
+    // Base query to fetch all trails in view for accurate clustering
+    const queries: any[] = [
+        {
+            indexUid: "trails",
+            q: "",
+            filter: [
+                `max_lat >= ${southWest.lat} AND min_lat <= ${northEast.lat} AND ${lonFilter}`,
+                filterText
+            ].filter(f => f !== ""),
+            attributesToRetrieve: defaultTrailSearchAttributes,
+            hitsPerPage: 1000,
+            page: page
+        }
+    ];
+
+    // If we want polylines, add a second query that includes them but is filtered by diagonal
+    // This query is only to retrieve polylines for trails that pass the filter
+    if (includePolyline || diagonalFilter !== "") {
+        queries.push({
+            indexUid: "trails",
+            q: "",
+            filter: [
+                `max_lat >= ${southWest.lat} AND min_lat <= ${northEast.lat} AND ${lonFilter}`,
+                filterText,
+                diagonalFilter
+            ].filter(f => f !== ""),
+            attributesToRetrieve: ["id", "polyline"],
+            hitsPerPage: 1000,
+            page: 1
+        });
+    }
+
+    let r = await fetch("/api/v1/search/multi", {
+        method: "POST",
+        body: JSON.stringify({ queries }),
+    });
+
+    if (!r.ok) {
+        const response = await r.json();
+        throw new APIError(r.status, response.message, response.detail)
+    }
+
+    const multiResult = await r.json();
+    const result = multiResult.results[0];
+
+    if (!result.hits || result.hits.length == 0) {
         trails = [];
         return { trails: [], ...result }
+    }
+
+    // If we have a second query result, merge the polylines
+    if (multiResult.results.length > 1) {
+        const polylineHits = multiResult.results[1].hits;
+        const polylineMap = new Map(polylineHits.map((h: any) => [h.id, h.polyline]));
+        result.hits.forEach((h: any) => {
+            if (polylineMap.has(h.id)) {
+                h.polyline = polylineMap.get(h.id);
+            }
+        });
     }
 
     const resultTrails: Trail[] = await searchResultToTrailList(result.hits)
@@ -130,8 +192,6 @@ export async function trails_search_bounding_box(northEast: M.LngLat, southWest:
     trails = page > 1 ? trails.concat(resultTrails) : resultTrails
 
     return { trails, ...result };
-
-
 }
 
 export async function trails_show(id: string, handle?: string, share?: string, loadGPX?: boolean, f: (url: RequestInfo | URL, config?: RequestInit) => Promise<Response> = fetch) {
@@ -480,6 +540,7 @@ export async function searchResultToTrailList(hits: Hits<TrailSearchResult>): Pr
             location: h.location,
             gpx: h.gpx,
             polyline: h.polyline,
+            bounding_box_diagonal: h.bounding_box_diagonal ?? 0,
             domain: h.domain,
             iri: h.iri,
             thumbnail: 0,

--- a/web/src/lib/stores/trail_store.ts
+++ b/web/src/lib/stores/trail_store.ts
@@ -15,11 +15,6 @@ import { tags_create } from "./tag_store";
 import { currentUser } from "./user_store";
 import { waypoints_create, waypoints_delete, waypoints_update } from "./waypoint_store";
 
-let trails: Trail[] = []
-export const trail: Writable<Trail> = writable(new Trail(""));
-
-export const editTrail: Writable<Trail> = writable(new Trail(""));
-
 export async function trails_index(perPage: number = 21, random: boolean = false, f: (url: RequestInfo | URL, config?: RequestInit) => Promise<Response> = fetch) {
     const r = await f('/api/v1/trail?' + new URLSearchParams({
         "perPage": perPage.toString(),
@@ -94,7 +89,21 @@ export async function trails_search_filter(filter: TrailFilter, page: number = 1
 
 }
 
-export async function trails_search_bounding_box(northEast: M.LngLat, southWest: M.LngLat, filter: TrailFilter, page: number = 1, zoom: number = 11, polylineMinZoom: number = 10) {
+export const MAP_LOW_ZOOM_THRESHOLD = Number(env.PUBLIC_MAP_LOW_ZOOM_THRESHOLD || 8);
+export const MAP_MEDIUM_ZOOM_THRESHOLD = Number(env.PUBLIC_MAP_MEDIUM_ZOOM_THRESHOLD || 10);
+
+export const MAP_LOW_ZOOM_DIAGONAL_LIMIT = Number(env.PUBLIC_MAP_LOW_ZOOM_DIAGONAL_LIMIT || 25000);
+export const MAP_MEDIUM_ZOOM_DIAGONAL_LIMIT = Number(env.PUBLIC_MAP_MEDIUM_ZOOM_DIAGONAL_LIMIT || 10000);
+export const MAP_HIGH_ZOOM_DIAGONAL_LIMIT = Number(env.PUBLIC_MAP_HIGH_ZOOM_DIAGONAL_LIMIT || 5000);
+
+let trails: Trail[] = []
+const detailedCache = new Map<string, Trail>();
+
+export const trail: Writable<Trail> = writable(new Trail(""));
+
+export const editTrail: Writable<Trail> = writable(new Trail(""));
+
+export async function trails_search_bounding_box(northEast: M.LngLat, southWest: M.LngLat, filter: TrailFilter, page: number = 1, zoom: number = 11, polylineMinZoom: number = 12) {
     const user = get(currentUser)
 
     let filterText: string = "";
@@ -104,63 +113,37 @@ export async function trails_search_bounding_box(northEast: M.LngLat, southWest:
     }
 
     const includePolyline = zoom >= polylineMinZoom;
-    const lowZoomDiagonal = Number(env.PUBLIC_MAP_LOW_ZOOM_DIAGONAL_LIMIT || 25000);
-    const mediumZoomDiagonal = Number(env.PUBLIC_MAP_MEDIUM_ZOOM_DIAGONAL_LIMIT || 10000);
-    const highZoomDiagonal = Number(env.PUBLIC_MAP_HIGH_ZOOM_DIAGONAL_LIMIT || 5000);
-
-    const lowZoomThreshold = Number(env.PUBLIC_MAP_LOW_ZOOM_THRESHOLD || 8);
-    const mediumZoomThreshold = Number(env.PUBLIC_MAP_MEDIUM_ZOOM_THRESHOLD || 10);
-    const highZoomThreshold = Number(env.PUBLIC_MAP_HIGH_ZOOM_THRESHOLD || 12);
-
-    let diagonalFilter = "";
-    if (zoom < lowZoomThreshold) {
-        diagonalFilter = `bounding_box_diagonal > ${lowZoomDiagonal}`;
-    } else if (zoom < mediumZoomThreshold) {
-        diagonalFilter = `bounding_box_diagonal > ${mediumZoomDiagonal}`;
-    } else if (zoom < highZoomThreshold) {
-        diagonalFilter = `bounding_box_diagonal > ${highZoomDiagonal}`;
-    }
 
     let lonFilter = `max_lon >= ${southWest.lng} AND min_lon <= ${northEast.lng}`;
     if (southWest.lng > northEast.lng) {
         lonFilter = `(max_lon >= ${southWest.lng} OR min_lon <= ${northEast.lng})`;
     }
 
-    // Base query to fetch all trails in view for accurate clustering
-    const queries: any[] = [
-        {
-            indexUid: "trails",
-            q: "",
-            filter: [
-                `max_lat >= ${southWest.lat} AND min_lat <= ${northEast.lat} AND ${lonFilter}`,
-                filterText
-            ].filter(f => f !== ""),
-            attributesToRetrieve: defaultTrailSearchAttributes,
-            hitsPerPage: 1000,
-            page: page
-        }
-    ];
+    const geoFilter = `max_lat >= ${southWest.lat} AND min_lat <= ${northEast.lat} AND ${lonFilter}`;
 
-    // If we want polylines, add a second query that includes them but is filtered by diagonal
-    // This query is only to retrieve polylines for trails that pass the filter
-    if (includePolyline || diagonalFilter !== "") {
-        queries.push({
-            indexUid: "trails",
-            q: "",
-            filter: [
-                `max_lat >= ${southWest.lat} AND min_lat <= ${northEast.lat} AND ${lonFilter}`,
-                filterText,
-                diagonalFilter
-            ].filter(f => f !== ""),
-            attributesToRetrieve: ["id", "polyline"],
-            hitsPerPage: 1000,
-            page: 1
-        });
+    // Determine the diagonal filter for visibility
+    let minDiagonal = 0;
+    if (zoom < MAP_LOW_ZOOM_THRESHOLD) {
+        minDiagonal = MAP_LOW_ZOOM_DIAGONAL_LIMIT;
+    } else if (zoom < MAP_MEDIUM_ZOOM_THRESHOLD) {
+        minDiagonal = MAP_MEDIUM_ZOOM_DIAGONAL_LIMIT;
+    } else if (zoom < polylineMinZoom) {
+        minDiagonal = MAP_HIGH_ZOOM_DIAGONAL_LIMIT;
     }
+
+    // Step 1: Lightweight summary for all trails in view (for accurate clustering)
+    const summaryQuery = {
+        indexUid: "trails",
+        q: "",
+        filter: [geoFilter, filterText].filter(f => f !== ""),
+        attributesToRetrieve: ["id", "_geo", "bounding_box_diagonal"],
+        hitsPerPage: 1000,
+        page: 1
+    };
 
     let r = await fetch("/api/v1/search/multi", {
         method: "POST",
-        body: JSON.stringify({ queries }),
+        body: JSON.stringify({ queries: [summaryQuery] }),
     });
 
     if (!r.ok) {
@@ -169,29 +152,94 @@ export async function trails_search_bounding_box(northEast: M.LngLat, southWest:
     }
 
     const multiResult = await r.json();
-    const result = multiResult.results[0];
+    const summaryHits = multiResult.results[0].hits;
 
-    if (!result.hits || result.hits.length == 0) {
+    if (!summaryHits || summaryHits.length == 0) {
         trails = [];
-        return { trails: [], ...result }
+        return { trails: [], ...multiResult.results[0] }
     }
 
-    // If we have a second query result, merge the polylines
-    if (multiResult.results.length > 1) {
-        const polylineHits = multiResult.results[1].hits;
-        const polylineMap = new Map(polylineHits.map((h: any) => [h.id, h.polyline]));
-        result.hits.forEach((h: any) => {
-            if (polylineMap.has(h.id)) {
-                h.polyline = polylineMap.get(h.id);
+    // Step 2: Identify which visible trails are MISSING from the local cache
+    const missingIds = summaryHits
+        .filter((h: any) => (h.bounding_box_diagonal ?? 0) > minDiagonal && !detailedCache.has(h.id))
+        .map((h: any) => h.id);
+
+    // Step 3: Only fetch details for missing trails
+    if (missingIds.length > 0) {
+        const batchSize = 100; // Meilisearch filter length safety
+        for (let i = 0; i < missingIds.length; i += batchSize) {
+            const batch = missingIds.slice(i, i + batchSize);
+            const detailBatchQuery = {
+                indexUid: "trails",
+                q: "",
+                filter: [`id IN [${batch.map((id: string) => `'${id}'`).join(",")}]`],
+                attributesToRetrieve: [...defaultTrailSearchAttributes, "polyline"],
+                hitsPerPage: batchSize,
+            };
+
+            const dr = await fetch("/api/v1/search/multi", {
+                method: "POST",
+                body: JSON.stringify({ queries: [detailBatchQuery] }),
+            });
+
+            if (dr.ok) {
+                const detailResult = await dr.json();
+                const newTrails = await searchResultToTrailList(detailResult.results[0].hits);
+                // Populate cache
+                newTrails.forEach(t => {
+                    if (t.id) detailedCache.set(t.id, t)
+                });
             }
-        });
+        }
     }
 
-    const resultTrails: Trail[] = await searchResultToTrailList(result.hits)
+    // Step 4: Convert summary hits to lightweight Trail objects
+    const summaryTrails: Trail[] = summaryHits.map((s: any) => {
+        if (detailedCache.has(s.id)) {
+            const cached = detailedCache.get(s.id)!;
+            // CRITICAL: Ensure cached object has fresh coordinates for clustering
+            cached.lat = s._geo.lat;
+            cached.lon = s._geo.lng;
+            cached.bounding_box_diagonal = s.bounding_box_diagonal ?? cached.bounding_box_diagonal;
+            return cached;
+        }
 
-    trails = page > 1 ? trails.concat(resultTrails) : resultTrails
+        // Lightweight fallback for map markers
+        const t: Trail & RecordModel = {
+            id: s.id,
+            lat: s._geo.lat,
+            lon: s._geo.lng,
+            name: "",
+            author: "",
+            photos: [],
+            public: true,
+            completed: false,
+            summit_logs: [],
+            waypoints: [],
+            tags: [],
+            category: "",
+            created: new Date(0).toISOString(),
+            date: new Date(0).toISOString(),
+            updated: new Date(0).toISOString(),
+            description: "",
+            difficulty: "easy",
+            distance: 0,
+            duration: 0,
+            elevation_gain: 0,
+            elevation_loss: 0,
+            location: "",
+            bounding_box_diagonal: s.bounding_box_diagonal ?? 0,
+            like_count: 0,
+            collectionId: "trails",
+            collectionName: "trails",
+            expand: { author: {} as any }
+        };
+        return t;
+    });
 
-    return { trails, ...result };
+    trails = page > 1 ? trails.concat(summaryTrails) : summaryTrails
+
+    return { trails, ...multiResult.results[0] };
 }
 
 export async function trails_show(id: string, handle?: string, share?: string, loadGPX?: boolean, f: (url: RequestInfo | URL, config?: RequestInit) => Promise<Response> = fetch) {
@@ -513,10 +561,12 @@ export async function fetchGPX(trail: { gpx?: string } & Record<string, any>, f:
 export async function searchResultToTrailList(hits: Hits<TrailSearchResult>): Promise<Trail[]> {
     const trails: Trail[] = []
     for (const h of hits) {
+        const created = Number(h.created || 0);
+        const date = Number(h.date || 0);
         const t: Trail & RecordModel = {
             collectionId: "trails",
             collectionName: "trails",
-            updated: new Date(h.created * 1000).toISOString(),
+            updated: new Date(created * 1000).toISOString(),
             author: h.author_name,
             name: h.name,
             photos: h.thumbnail ? [h.thumbnail] : [],
@@ -526,8 +576,8 @@ export async function searchResultToTrailList(hits: Hits<TrailSearchResult>): Pr
             waypoints: [],
             tags: h.tags ?? [],
             category: h.category,
-            created: new Date(h.created * 1000).toISOString(),
-            date: new Date(h.date * 1000).toISOString(),
+            created: new Date(created * 1000).toISOString(),
+            date: new Date(date * 1000).toISOString(),
             description: h.description,
             difficulty: h.difficulty == 0 ? "easy" : h.difficulty == 1 ? "moderate" : "difficult",
             distance: h.distance,

--- a/web/src/lib/vendor/maplibre-layer-manager/caret-layer.ts
+++ b/web/src/lib/vendor/maplibre-layer-manager/caret-layer.ts
@@ -9,6 +9,7 @@ export class CaretLayer implements BaseLayer {
         this.spec = {
             version: 8,
             name: "direction-carets",
+            glyphs: "https://tiles.openfreemap.org/fonts/{fontstack}/{range}.pbf",
             sources: {
                 caret: source
             },

--- a/web/src/lib/vendor/maplibre-layer-manager/cluster-layer.ts
+++ b/web/src/lib/vendor/maplibre-layer-manager/cluster-layer.ts
@@ -22,12 +22,16 @@ export class ClusterLayer implements BaseLayer {
         }
     };
 
-    constructor(map: M.Map, geojson: GeoJSON.FeatureCollection, listeners?: Record<string, { onMouseUp?: (e: MapMouseEvent) => void; onMouseDown?: (e: MapMouseEvent) => void; onEnter?: (e: MapMouseEvent) => void; onLeave?: (e: MapMouseEvent) => void; onMouseMove?: (e: MapMouseEvent) => void; }>) {
+    constructor(map: M.Map, geojson: GeoJSON.FeatureCollection, maxZoom: number = 10, tiers?: { thresholds: number[], limits: number[] }, listeners?: Record<string, { onMouseUp?: (e: MapMouseEvent) => void; onMouseDown?: (e: MapMouseEvent) => void; onEnter?: (e: MapMouseEvent) => void; onLeave?: (e: MapMouseEvent) => void; onMouseMove?: (e: MapMouseEvent) => void; }>) {
         this.map = map;
         this.listeners = {
             "clusters": { ...this.listeners["clusters"], ...listeners?.["clusters"] },
             "unclustered-point": { ...this.listeners["unclustered-point"], ...listeners?.["unclustered-point"] }
         }
+
+        const thresholds = tiers?.thresholds || [8, 10, 12];
+        const limits = tiers?.limits || [25000, 10000, 5000];
+
         this.spec = {
             version: 8,
             name: "clusters",
@@ -38,6 +42,7 @@ export class ClusterLayer implements BaseLayer {
                     data: geojson,
                     cluster: true,
                     clusterRadius: 50,
+                    clusterMaxZoom: maxZoom,
                 }
             },
             layers: [
@@ -46,7 +51,7 @@ export class ClusterLayer implements BaseLayer {
                     type: "circle",
                     source: "cluster-trails",
                     filter: ["has", "point_count"],
-                    maxzoom: 10,
+                    maxzoom: maxZoom + 1, // Allow clusters to stay a bit longer if needed
                     paint: {
                         "circle-color": "#242734",
                         "circle-radius": [
@@ -73,7 +78,7 @@ export class ClusterLayer implements BaseLayer {
                     type: "symbol",
                     source: "cluster-trails",
                     filter: ["has", "point_count"],
-                    maxzoom: 10,
+                    maxzoom: maxZoom + 1,
                     paint: {
                         "text-color": "#fff",
                     },
@@ -87,8 +92,22 @@ export class ClusterLayer implements BaseLayer {
                     id: "unclustered-point",
                     type: "circle",
                     source: "cluster-trails",
-                    maxzoom: 10,
-                    filter: ["!", ["has", "point_count"]],
+                    filter: [
+                        "all",
+                        ["!", ["has", "point_count"]],
+                        [
+                            "<",
+                            ["get", "bounding_box_diagonal"],
+                            [
+                                "step",
+                                ["zoom"],
+                                limits[0],
+                                thresholds[0], limits[1],
+                                thresholds[1], limits[2],
+                                thresholds[2], 0
+                            ]
+                        ]
+                    ],
                     paint: {
                         "circle-color": "#242734",
                         "circle-radius": 7,

--- a/web/src/lib/vendor/maplibre-layer-manager/cluster-layer.ts
+++ b/web/src/lib/vendor/maplibre-layer-manager/cluster-layer.ts
@@ -29,8 +29,26 @@ export class ClusterLayer implements BaseLayer {
             "unclustered-point": { ...this.listeners["unclustered-point"], ...listeners?.["unclustered-point"] }
         }
 
-        const thresholds = tiers?.thresholds || [8, 10, 12];
-        const limits = tiers?.limits || [25000, 10000, 5000];
+        const pairs = (tiers?.thresholds || [8, 10, 12]).map((t, i) => ({
+            threshold: t,
+            limit: (tiers?.limits || [25000, 10000, 5000])[i]
+        })).sort((a, b) => a.threshold - b.threshold);
+
+        const thresholds: number[] = [];
+        const limits: number[] = [];
+        let lastT = -1;
+        for (const p of pairs) {
+            if (p.threshold > lastT) {
+                thresholds.push(p.threshold);
+                limits.push(p.limit);
+                lastT = p.threshold;
+            }
+        }
+
+        const stepExpr: any[] = ["step", ["zoom"], limits[0]];
+        for (let i = 0; i < thresholds.length; i++) {
+            stepExpr.push(thresholds[i], limits[i + 1] ?? 0);
+        }
 
         this.spec = {
             version: 8,
@@ -51,7 +69,7 @@ export class ClusterLayer implements BaseLayer {
                     type: "circle",
                     source: "cluster-trails",
                     filter: ["has", "point_count"],
-                    maxzoom: maxZoom + 1, // Allow clusters to stay a bit longer if needed
+                    maxzoom: maxZoom,
                     paint: {
                         "circle-color": "#242734",
                         "circle-radius": [
@@ -78,7 +96,7 @@ export class ClusterLayer implements BaseLayer {
                     type: "symbol",
                     source: "cluster-trails",
                     filter: ["has", "point_count"],
-                    maxzoom: maxZoom + 1,
+                    maxzoom: maxZoom,
                     paint: {
                         "text-color": "#fff",
                     },
@@ -92,20 +110,14 @@ export class ClusterLayer implements BaseLayer {
                     id: "unclustered-point",
                     type: "circle",
                     source: "cluster-trails",
+                    maxzoom: maxZoom,
                     filter: [
                         "all",
                         ["!", ["has", "point_count"]],
                         [
                             "<",
                             ["get", "bounding_box_diagonal"],
-                            [
-                                "step",
-                                ["zoom"],
-                                limits[0],
-                                thresholds[0], limits[1],
-                                thresholds[1], limits[2],
-                                thresholds[2], 0
-                            ]
+                            stepExpr as any
                         ]
                     ],
                     paint: {

--- a/web/src/lib/vendor/maplibre-layer-manager/preview-layer.ts
+++ b/web/src/lib/vendor/maplibre-layer-manager/preview-layer.ts
@@ -18,7 +18,7 @@ export class PreviewLayer implements BaseLayer {
         }
     };
 
-    constructor(map: M.Map, geojson: GeoJSON.FeatureCollection, listeners?: Record<string, { onMouseUp?: (e: MapMouseEvent) => void; onMouseDown?: (e: MapMouseEvent) => void; onEnter?: (e: MapMouseEvent) => void; onLeave?: (e: MapMouseEvent) => void; onMouseMove?: (e: MapMouseEvent) => void; }>) {
+    constructor(map: M.Map, geojson: GeoJSON.FeatureCollection, minZoom: number = 10, listeners?: Record<string, { onMouseUp?: (e: MapMouseEvent) => void; onMouseDown?: (e: MapMouseEvent) => void; onEnter?: (e: MapMouseEvent) => void; onLeave?: (e: MapMouseEvent) => void; onMouseMove?: (e: MapMouseEvent) => void; }>) {
 
         this.map = map;
         this.listeners = {
@@ -58,7 +58,7 @@ export class PreviewLayer implements BaseLayer {
                     id: "preview",
                     type: "line",
                     source: "preview",
-                    minzoom: 10,
+                    minzoom: minZoom,
                     paint: {
                         "line-color": ["get", "color"],
                         "line-width": 5,
@@ -68,7 +68,7 @@ export class PreviewLayer implements BaseLayer {
                     id: "preview-start-points",
                     type: "circle",
                     source: "preview-start-points",
-                    minzoom: 10,
+                    minzoom: minZoom,
                     paint: {
                         "circle-color": "#242734",
                         "circle-radius": 6,
@@ -80,7 +80,7 @@ export class PreviewLayer implements BaseLayer {
                     id: "preview-direction-carets",
                     type: "symbol",
                     source: "preview",
-                    minzoom: 10,
+                    minzoom: minZoom,
                     layout: {
                         "symbol-placement": "line",
                         "symbol-spacing": [

--- a/web/src/lib/vendor/maplibre-layer-manager/preview-layer.ts
+++ b/web/src/lib/vendor/maplibre-layer-manager/preview-layer.ts
@@ -18,12 +18,45 @@ export class PreviewLayer implements BaseLayer {
         }
     };
 
-    constructor(map: M.Map, geojson: GeoJSON.FeatureCollection, minZoom: number = 10, listeners?: Record<string, { onMouseUp?: (e: MapMouseEvent) => void; onMouseDown?: (e: MapMouseEvent) => void; onEnter?: (e: MapMouseEvent) => void; onLeave?: (e: MapMouseEvent) => void; onMouseMove?: (e: MapMouseEvent) => void; }>) {
+    constructor(map: M.Map, geojson: GeoJSON.FeatureCollection, minZoom: number = 10, options?: { tiers?: { thresholds: number[], limits: number[] }, listeners?: Record<string, { onMouseUp?: (e: MapMouseEvent) => void; onMouseDown?: (e: MapMouseEvent) => void; onEnter?: (e: MapMouseEvent) => void; onLeave?: (e: MapMouseEvent) => void; onMouseMove?: (e: MapMouseEvent) => void; }> }) {
 
         this.map = map;
+        const listeners = options?.listeners;
         this.listeners = {
             "preview": { ...this.listeners["preview"], ...listeners?.["preview"] },
             "preview-start-points": { ...this.listeners["preview-start-points"], ...listeners?.["preview-start-points"] }
+        }
+
+        const tiers = options?.tiers;
+        let lineFilter: M.FilterSpecification | undefined = undefined;
+
+        if (tiers) {
+            const pairs = tiers.thresholds.map((t, i) => ({
+                threshold: t,
+                limit: tiers.limits[i]
+            })).sort((a, b) => a.threshold - b.threshold);
+
+            const thresholds: number[] = [];
+            const limits: number[] = [];
+            let lastT = -1;
+            for (const p of pairs) {
+                if (p.threshold > lastT) {
+                    thresholds.push(p.threshold);
+                    limits.push(p.limit);
+                    lastT = p.threshold;
+                }
+            }
+
+            const stepExpr: any[] = ["step", ["zoom"], limits[0]];
+            for (let i = 0; i < thresholds.length; i++) {
+                stepExpr.push(thresholds[i], limits[i + 1] ?? 0);
+            }
+
+            lineFilter = [
+                ">",
+                ["get", "bounding_box_diagonal"],
+                stepExpr as any
+            ];
         }
 
         const startPoints: GeoJSON.FeatureCollection = {
@@ -43,6 +76,7 @@ export class PreviewLayer implements BaseLayer {
         this.spec = {
             version: 8,
             name: "preview",
+            glyphs: "https://tiles.openfreemap.org/fonts/{fontstack}/{range}.pbf",
             sources: {
                 "preview": {
                     type: "geojson",
@@ -59,6 +93,7 @@ export class PreviewLayer implements BaseLayer {
                     type: "line",
                     source: "preview",
                     minzoom: minZoom,
+                    filter: lineFilter,
                     paint: {
                         "line-color": ["get", "color"],
                         "line-width": 5,

--- a/web/src/lib/vendor/maplibre-layer-manager/trail-layer.ts
+++ b/web/src/lib/vendor/maplibre-layer-manager/trail-layer.ts
@@ -1,4 +1,4 @@
-import type { MapMouseEvent, Marker, StyleSpecification } from "maplibre-gl";
+import type { FilterSpecification, MapMouseEvent, Marker, StyleSpecification } from "maplibre-gl";
 import type { BaseLayer } from "./layers";
 
 export class TrailLayer implements BaseLayer {
@@ -7,7 +7,44 @@ export class TrailLayer implements BaseLayer {
     listeners: Record<string, { onMouseUp?: (e: MapMouseEvent) => void; onMouseDown?: (e: MapMouseEvent) => void; onEnter?: (e: MapMouseEvent) => void; onLeave?: (e: MapMouseEvent) => void; onMouseMove?: (e: MapMouseEvent) => void; }>
     markers: Record<string, Marker> = {};
 
-    constructor(id: string, geojson: GeoJSON.FeatureCollection, color: string, listerners?: { onMouseUp?: (e: MapMouseEvent) => void; onMouseDown?: (e: MapMouseEvent) => void; onEnter?: (e: MapMouseEvent) => void; onLeave?: (e: MapMouseEvent) => void; onMouseMove?: (e: MapMouseEvent) => void; }) {
+    constructor(id: string, geojson: GeoJSON.FeatureCollection, color: string, options?: {
+        minZoom?: number,
+        maxZoom?: number,
+        tiers?: { thresholds: number[], limits: number[] },
+        listeners?: { onMouseUp?: (e: MapMouseEvent) => void; onMouseDown?: (e: MapMouseEvent) => void; onEnter?: (e: MapMouseEvent) => void; onLeave?: (e: MapMouseEvent) => void; onMouseMove?: (e: MapMouseEvent) => void; }
+    }) {
+        const tiers = options?.tiers;
+        let filter: FilterSpecification | undefined = undefined;
+
+        if (tiers) {
+            const pairs = tiers.thresholds.map((t, i) => ({
+                threshold: t,
+                limit: tiers.limits[i]
+            })).sort((a, b) => a.threshold - b.threshold);
+
+            const thresholds: number[] = [];
+            const limits: number[] = [];
+            let lastT = -1;
+            for (const p of pairs) {
+                if (p.threshold > lastT) {
+                    thresholds.push(p.threshold);
+                    limits.push(p.limit);
+                    lastT = p.threshold;
+                }
+            }
+
+            const stepExpr: any[] = ["step", ["zoom"], limits[0]];
+            for (let i = 0; i < thresholds.length; i++) {
+                stepExpr.push(thresholds[i], limits[i + 1] ?? 0);
+            }
+
+            filter = [
+                ">",
+                ["get", "bounding_box_diagonal"],
+                stepExpr as any
+            ];
+        }
+
         this.spec = {
             version: 8,
             name: id,
@@ -21,6 +58,9 @@ export class TrailLayer implements BaseLayer {
                 id: id,
                 type: "line",
                 source: id,
+                minzoom: options?.minZoom,
+                maxzoom: options?.maxZoom,
+                filter: filter,
                 paint: {
                     "line-color": color,
                     "line-width": 5,
@@ -29,6 +69,6 @@ export class TrailLayer implements BaseLayer {
 
         };
 
-        this.listeners = { [id]: listerners ?? {} }
+        this.listeners = { [id]: options?.listeners ?? {} }
     }
 }

--- a/web/src/routes/map/+page.svelte
+++ b/web/src/routes/map/+page.svelte
@@ -77,6 +77,8 @@
         },
     };
 
+    const clusterMinZoom = settings?.behavior?.mapClusterMinZoom ?? Number(env.PUBLIC_MAP_HIGH_ZOOM_THRESHOLD || 12);
+
     async function search(q: string) {
         const r = await searchMulti({
             queries: [
@@ -148,7 +150,7 @@
             filter,
             pagination.page,
             map?.getZoom() ?? 0,
-            settings?.behavior?.mapClusterMinZoom ?? Number(env.PUBLIC_MAP_HIGH_ZOOM_THRESHOLD || 12),
+            clusterMinZoom,
         );
         pagination.totalPages = trailsInBox.totalPages;
         trails = trailsInBox.trails;
@@ -393,7 +395,7 @@
                 {#if trails.length == 0}
                     <EmptyStateSearch></EmptyStateSearch>
                 {/if}
-                {#each trails as trail, i}
+                {#each trails.filter(t => t.name !== "") as trail, i}
                     <a
                         href="/map/trail/@{trail.author}{trail.domain
                             ? `@${trail.domain}`
@@ -428,7 +430,7 @@
             activeTrail={-1}
             fitBounds="off"
             clusterTrails={true}
-            clusterMinZoom={settings?.behavior?.mapClusterMinZoom ?? Number(env.PUBLIC_MAP_HIGH_ZOOM_THRESHOLD || 12)}
+            clusterMinZoom={clusterMinZoom}
             bind:map
 
             bind:this={mapWithElevation}

--- a/web/src/routes/map/+page.svelte
+++ b/web/src/routes/map/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { browser } from "$app/environment";
     import { goto } from "$app/navigation";
+    import { env } from '$env/dynamic/public';
     import { page } from "$app/state";
     import Search, {
         type SearchItem,
@@ -98,19 +99,19 @@
             ],
         });
 
-        const trailItems = r[0].hits.map((t: TrailSearchResult) => ({
+        const trailItems = (r[0]?.hits || []).map((t: TrailSearchResult) => ({
             text: t.name,
             description: `Trail ${t.location.length ? ", " + t.location : ""}`,
             value: `@${t.author_name}${t.domain ? `@${t.domain}` : ""}/${t.id}`,
             icon: "route",
         }));
-        const listItems = r[1].hits.map((t: ListSearchResult) => ({
+        const listItems = (r[1]?.hits || []).map((t: ListSearchResult) => ({
             text: t.name,
             description: `List, ${t.trails} ${$_("trail", { values: { n: t.trails } })}`,
             value: t.id,
             icon: "layer-group",
         }));
-        const cityItems = r[2].hits.map((c: LocationSearchResult) => ({
+        const cityItems = (r[2]?.hits || []).map((c: LocationSearchResult) => ({
             text: c.name,
             description: c.description,
             value: c,
@@ -146,7 +147,8 @@
             southWest,
             filter,
             pagination.page,
-            (map?.getZoom() ?? 0) > MIN_ZOOM,
+            map?.getZoom() ?? 0,
+            settings?.behavior?.mapClusterMinZoom ?? Number(env.PUBLIC_MAP_HIGH_ZOOM_THRESHOLD || 12),
         );
         pagination.totalPages = trailsInBox.totalPages;
         trails = trailsInBox.trails;
@@ -426,7 +428,9 @@
             activeTrail={-1}
             fitBounds="off"
             clusterTrails={true}
+            clusterMinZoom={settings?.behavior?.mapClusterMinZoom ?? Number(env.PUBLIC_MAP_HIGH_ZOOM_THRESHOLD || 12)}
             bind:map
+
             bind:this={mapWithElevation}
         ></MapWithElevationMaplibre>
     </div>

--- a/web/src/routes/settings/map/+page.svelte
+++ b/web/src/routes/settings/map/+page.svelte
@@ -25,20 +25,32 @@
     let allowAutoGeolocate = $state(
         page.data.settings.behavior?.allowAutoGeolocate ?? false,
     );
+    let mapClusterMinZoom = $state(
+        page.data.settings.behavior?.mapClusterMinZoom ?? 10,
+    );
 
-    async function handleAllowAutoGeolocateChange() {
+    $effect(() => {
+        if (settings?.behavior) {
+            allowAutoGeolocate = settings.behavior.allowAutoGeolocate ?? false;
+            mapClusterMinZoom = settings.behavior.mapClusterMinZoom ?? 10;
+        }
+    });
+
+    async function handleBehaviorChange() {
         if (!settings) {
             return;
         }
 
         try {
-            if (!settings.behavior) {
-                settings.behavior = { allowAutoGeolocate: allowAutoGeolocate };
-            } else {
-                settings.behavior.allowAutoGeolocate = allowAutoGeolocate;
-            }
+            const updatedSettings = {
+                ...settings,
+                behavior: {
+                    allowAutoGeolocate: allowAutoGeolocate,
+                    mapClusterMinZoom: Number(mapClusterMinZoom),
+                },
+            };
 
-            await settings_update(settings);
+            await settings_update(updatedSettings);
         } catch (e) {
             show_toast({
                 type: "error",
@@ -166,16 +178,31 @@
                     ></Search>
                 </div>
             {/if}
-            <div
-                class="mt-4 grid gap-4"
-                style="grid-template-columns: 1fr min-content ;"
-            >
-                <p>{$_("allow-auto-geolocate")}</p>
-                <div>
-                    <Toggle
-                        bind:value={allowAutoGeolocate}
-                        onchange={handleAllowAutoGeolocateChange}
-                    ></Toggle>
+            <div class="mt-8 space-y-4">
+                <div
+                    class="grid gap-4 items-center"
+                    style="grid-template-columns: 1fr min-content ;"
+                >
+                    <p>{$_("allow-auto-geolocate")}</p>
+                    <div>
+                        <Toggle
+                            bind:value={allowAutoGeolocate}
+                            onchange={handleBehaviorChange}
+                        ></Toggle>
+                    </div>
+                </div>
+                <div
+                    class="grid gap-4 items-center"
+                    style="grid-template-columns: 1fr 100px ;"
+                >
+                    <p>{$_("map-cluster-zoom-level")}</p>
+                    <div>
+                        <TextField
+                            bind:value={mapClusterMinZoom}
+                            type="number"
+                            onchange={handleBehaviorChange}
+                        ></TextField>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
related to #935 and depends on #958 

Feature Overview: Map Clustering & Zoom Optimization

  To address performance and prevent the map from being overwhelmed with thousands of tracks at low zoom levels,
  this branch introduces a tiered clustering and visibility system. It balances server performance, network traffic,
  and user preference.

  1. The Bounding Box Diagonal (bounding_box_diagonal)
  Instead of filtering tracks by their actual route distance (which might zig-zag inside a small area), we calculate
  the diagonal length of the track's bounding box.
   * Why? This accurately represents the visual size of the track on the map. A 50km track tightly wound inside a
     2km forest will look like a single speck when zoomed out, whereas a 50km point-to-point track will span across
     the screen.
   * By filtering on the diagonal, we efficiently determine which tracks are visually relevant at any given
     altitude.

  2. Tiered Visibility & Zooming Out (Performance)
  The system uses environment variables to define "tiers" of visibility based on the current zoom level and the
  track's diagonal. This is critical for performance when the user zooms out and pans across large areas.

  Instead of forcing the browser to maintain and redraw thousands of tiny, sub-pixel tracks, the map dynamically
  sheds detail as you zoom out:
   * High Zoom (Detailed View): Shows all polylines or individual markers.
   * Medium Zoom (PUBLIC_MAP_MEDIUM_ZOOM_THRESHOLD defaults to 10): As you zoom out past this threshold, the map
     drops all small tracks (diagonal < 10000 meters) from the unclustered rendering queue.
   * Low Zoom (PUBLIC_MAP_LOW_ZOOM_THRESHOLD defaults to 8): Zooming out further drops medium tracks (diagonal <
     25000 meters).

  The Performance Impact: When a user is zoomed out to a country level and starts panning, the browser is only
  calculating draw-calls for a handful of massive, visually significant tracks, rather than choking on rendering
  10,000 tiny local hikes. (Note: These hidden tracks are still accurately summarized in the cluster bubbles—no data
  is "lost" to the user).

  3. User Preference vs. System Limits
  While environment variables protect the server and browser from overload, the user has ultimate control over when
  to transition from "Clusters/Dots" to actual "Polylines".

   * settings.behavior.mapClusterMinZoom: This user setting dictates the exact zoom level where clusters disappear
     and the full trail paths are drawn.
   * If the user has a powerful device and wants to see polylines earlier, they can set this to a lower number
     (e.g., 5). The system perfectly syncs the data fetching and map rendering layers to this single threshold,
     eliminating "dead zones" or "rough transitions" where tracks overlap or disappear.
   * If the user hasn't configured this, it defaults to the PUBLIC_MAP_HIGH_ZOOM_THRESHOLD (default 12).

  4. Two-Tiered Network Optimization
  To ensure the cluster counts are 100% accurate at global zoom levels without destroying network bandwidth, we
  implemented a dual-query approach:
   1. Summary Query: Fetches extremely lightweight objects (id, _geo, bounding_box_diagonal) for all tracks in the
      viewport. This guarantees accurate cluster numbers regardless of how far out you zoom.
   2. Detailed Query: Fetches the heavy metadata (Polylines, Names, Authors, Tags) only for the tracks that pass the
      diagonal visibility filter at the current zoom level.
   3. Client-Side Cache: Once a detailed track is downloaded, the frontend caches it. Panning back to a previously
      viewed area requires 0 additional network traffic for detailed metadata.