### PR TITLE
prevent uploading gpx twice when creating a trail

### DIFF
--- a/web/src/lib/stores/trail_store.ts
+++ b/web/src/lib/stores/trail_store.ts
@@ -197,7 +197,7 @@ export async function trails_create(trail: Trail, photos: File[], gpx: File | Bl
 
     trail.author = user.actor
 
-    const formData = objectToFormData(trail)
+    const formData = objectToFormData(trail, ["expand"])
 
     if (gpx) {
         formData.set("gpx", gpx);


### PR DESCRIPTION
Hi,

While investigating a 'payload too large' error caused by a misconfiguration in my local setup, I noticed that the GPX file is uploaded twice during trail creation: once as a dedicated file field and once as part of the serialized expand.gpx_data string. This PR fixes that by excluding expand from the form data serialization in trails_create, consistent with how trails_update already handles it.