### PR TITLE
fix email change issues

### DIFF
--- a/db/hooks/users.go
+++ b/db/hooks/users.go
@@ -87,17 +87,6 @@ func UpdateUserHandler(client meilisearch.ServiceManager) func(e *core.RecordEve
 	}
 }
 
-func ChangeUserEmailHandler() func(e *core.RecordRequestEmailChangeRequestEvent) error {
-	return func(e *core.RecordRequestEmailChangeRequestEvent) error {
-
-		e.Record.Set("email", e.NewEmail)
-		if err := e.App.Save(e.Record); err != nil {
-			return err
-		}
-		return nil
-	}
-}
-
 func createDefaultUserSettings(app core.App, userId string) error {
 	collection, err := app.FindCollectionByNameOrId("settings")
 	if err != nil {

--- a/db/main.go
+++ b/db/main.go
@@ -88,7 +88,6 @@ func registerMigrations(app *pocketbase.PocketBase) {
 func setupEventHandlers(app *pocketbase.PocketBase, client meilisearch.ServiceManager) {
 	app.OnRecordAfterCreateSuccess("users").BindFunc(hooks.CreateUserHandler(client))
 	app.OnRecordAfterUpdateSuccess("users").BindFunc(hooks.UpdateUserHandler(client))
-	app.OnRecordRequestEmailChangeRequest("users").BindFunc(hooks.ChangeUserEmailHandler())
 
 	app.OnRecordAfterCreateSuccess("trails").BindFunc(hooks.CreateTrailHandler(client))
 	app.OnRecordAfterUpdateSuccess("trails").BindFunc(hooks.UpdateTrailHandler(client))
@@ -155,6 +154,7 @@ func registerRoutes(se *core.ServeEvent, client meilisearch.ServiceManager) {
 	se.Router.GET("/health", routes.Health)
 
 	se.Router.POST("/auth/token", routes.AuthToken)
+	se.Router.POST("/user/email", routes.UserEmailChange)
 	se.Router.POST("/waypoint/cluster", routes.WaypointCluster)
 
 	se.Router.POST("/trail-merge/suggest", routes.TrailMergeSuggest)

--- a/db/routes/user_email_change.go
+++ b/db/routes/user_email_change.go
@@ -1,10 +1,14 @@
 package routes
 
 import (
+	"errors"
 	"net/http"
 
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/pocketbase/pocketbase/apis"
 	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/mails"
+	"github.com/pocketbase/pocketbase/tools/routine"
 )
 
 func UserEmailChange(e *core.RequestEvent) error {
@@ -13,7 +17,8 @@ func UserEmailChange(e *core.RequestEvent) error {
 	}
 
 	var data struct {
-		Email string `json:"email"`
+		Email    string `json:"email"`
+		Password string `json:"password"`
 	}
 	if err := e.BindBody(&data); err != nil {
 		return apis.NewBadRequestError("Failed to read request data", err)
@@ -21,11 +26,29 @@ func UserEmailChange(e *core.RequestEvent) error {
 	if data.Email == "" {
 		return apis.NewBadRequestError("Email is required", nil)
 	}
+	if data.Password == "" {
+		return apis.NewBadRequestError("Current password is required", nil)
+	}
+	if !e.Auth.ValidatePassword(data.Password) {
+		return apis.NewBadRequestError("Invalid password", nil)
+	}
 
 	e.Auth.Set("email", data.Email)
+	e.Auth.Set("verified", false)
 	if err := e.App.Save(e.Auth); err != nil {
+		var verr validation.Errors
+		if errors.As(err, &verr) {
+			return apis.NewBadRequestError("Validation failed", verr)
+		}
 		return err
 	}
+
+	app := e.App
+	routine.FireAndForget(func() {
+		if err := mails.SendRecordVerification(app, e.Auth); err != nil {
+			app.Logger().Error("Failed to send verification email", "error", err)
+		}
+	})
 
 	token, err := e.Auth.NewAuthToken()
 	if err != nil {

--- a/db/routes/user_email_change.go
+++ b/db/routes/user_email_change.go
@@ -1,0 +1,39 @@
+package routes
+
+import (
+	"net/http"
+
+	"github.com/pocketbase/pocketbase/apis"
+	"github.com/pocketbase/pocketbase/core"
+)
+
+func UserEmailChange(e *core.RequestEvent) error {
+	if e.Auth == nil {
+		return apis.NewUnauthorizedError("Authentication required", nil)
+	}
+
+	var data struct {
+		Email string `json:"email"`
+	}
+	if err := e.BindBody(&data); err != nil {
+		return apis.NewBadRequestError("Failed to read request data", err)
+	}
+	if data.Email == "" {
+		return apis.NewBadRequestError("Email is required", nil)
+	}
+
+	e.Auth.Set("email", data.Email)
+	if err := e.App.Save(e.Auth); err != nil {
+		return err
+	}
+
+	token, err := e.Auth.NewAuthToken()
+	if err != nil {
+		return err
+	}
+
+	return e.JSON(http.StatusOK, map[string]any{
+		"token":  token,
+		"record": e.Auth,
+	})
+}

--- a/web/src/lib/components/settings/email_modal.svelte
+++ b/web/src/lib/components/settings/email_modal.svelte
@@ -9,7 +9,7 @@
 
     interface Props {
         email?: string;
-        onsave?: (email: string) => void;
+        onsave?: (email: string, currentPassword: string) => void;
     }
 
     let { email = "", onsave }: Props = $props();
@@ -18,24 +18,28 @@
 
     export function openModal() {
         setFields("email", email);
+        setFields("currentPassword", "");
         setErrors("email", []);
+        setErrors("currentPassword", []);
         modal.openModal();
     }
 
     const { form, errors, setFields, setErrors } = createForm<{
         email: string;
+        currentPassword: string;
     }>({
-        initialValues: { email: untrack(() => email) },
+        initialValues: { email: untrack(() => email), currentPassword: "" },
         extend: validator({
             schema: z.object({
                 email: z
                     .string()
                     .min(1, "required")
                     .email("not-a-valid-email-address"),
+                currentPassword: z.string().min(1, "required"),
             }),
         }),
         onSubmit: async (form) => {
-            onsave?.(form.email);
+            onsave?.(form.email, form.currentPassword);
             modal.closeModal!();
         },
     });
@@ -48,8 +52,9 @@
     bind:this={modal}
 >
     {#snippet content()}
-        <form id="email-form" use:form>
-            <TextField name="email" error={$errors.email}></TextField>
+        <form id="email-form" use:form class="flex flex-col gap-4">
+            <TextField name="email" label={$_("email")} error={$errors.email}></TextField>
+            <TextField name="currentPassword" type="password" label={$_("current-password")} error={$errors.currentPassword}></TextField>
         </form>
     {/snippet}
     {#snippet footer()}

--- a/web/src/lib/stores/user_store.ts
+++ b/web/src/lib/stores/user_store.ts
@@ -78,9 +78,10 @@ export async function logout() {
 }
 
 export async function users_update(user: User | { [K in keyof User]?: User[K] }, avatar?: File) {
+    const { email: _email, ...payload } = user as any;
     let r = await fetch('/api/v1/user/' + user.id, {
         method: 'POST',
-        body: JSON.stringify(user)
+        body: JSON.stringify(payload)
     })
 
     if (!r.ok) {
@@ -119,6 +120,22 @@ export async function users_update(user: User | { [K in keyof User]?: User[K] },
     }
 
     currentUser.set(merged);
+}
+
+export async function users_update_email(userId: string, email: string, currentPassword: string) {
+    const r = await fetch(`/api/v1/user/${userId}/email`, {
+        method: 'POST',
+        body: JSON.stringify({ email, currentPassword }),
+    });
+
+    if (!r.ok) {
+        const response = await r.json();
+        throw new APIError(r.status, response.message, response.detail);
+    }
+
+    const model: User = await r.json();
+    const existing = get(currentUser);
+    currentUser.set({ ...(existing ?? {}), ...model } as User);
 }
 
 export async function users_delete(user: User) {

--- a/web/src/routes/api/v1/user/[id]/+server.ts
+++ b/web/src/routes/api/v1/user/[id]/+server.ts
@@ -83,23 +83,20 @@ export async function POST(event: RequestEvent) {
         const params = event.params
         const safeParams = RecordIdSchema.parse(params);
 
-        const safeData = UserUpdateSchema.parse(data);
-
-        const { email: _email, ...updateData } = safeData;
-
-        const r = await event.locals.pb.collection('users').update<User>(safeParams.id, updateData)
-
-        if (safeData.email && safeData.email != event.locals.pb.authStore.record!.email) {
-            const emailChange = await event.locals.pb.send('/user/email', {
-                method: 'POST',
-                body: JSON.stringify({ email: safeData.email }),
-            });
-            event.locals.pb.authStore.save(emailChange.token, emailChange.record);
-            r.email = safeData.email;
+        if (safeParams.id !== event.locals.pb.authStore.record!.id) {
+            return json({ message: 'Forbidden' }, { status: 403 });
         }
 
+        if (data.email !== undefined) {
+            return json({ message: 'Use POST /api/v1/user/{id}/email for email changes' }, { status: 400 });
+        }
+
+        const safeData = UserUpdateSchema.parse(data);
+        const { email: _email, ...updateData } = safeData;
+        const r = await event.locals.pb.collection('users').update<User>(safeParams.id, updateData)
+
         if (safeData.password) {
-            const authR = await event.locals.pb.collection('users').authWithPassword(safeData.email ?? event.locals.pb.authStore.record!.email, safeData.password);
+            const authR = await event.locals.pb.collection('users').authWithPassword(event.locals.pb.authStore.record!.email, safeData.password);
             return json(authR.record)
         }
         return json(r);

--- a/web/src/routes/api/v1/user/[id]/+server.ts
+++ b/web/src/routes/api/v1/user/[id]/+server.ts
@@ -85,17 +85,24 @@ export async function POST(event: RequestEvent) {
 
         const safeData = UserUpdateSchema.parse(data);
 
+        const { email: _email, ...updateData } = safeData;
+
+        const r = await event.locals.pb.collection('users').update<User>(safeParams.id, updateData)
+
         if (safeData.email && safeData.email != event.locals.pb.authStore.record!.email) {
-            const r = await event.locals.pb.collection('users').requestEmailChange(safeData.email);
-            event.locals.pb.authStore.record!.email = safeData.email;
+            const emailChange = await event.locals.pb.send('/user/email', {
+                method: 'POST',
+                body: JSON.stringify({ email: safeData.email }),
+            });
+            event.locals.pb.authStore.save(emailChange.token, emailChange.record);
+            r.email = safeData.email;
         }
-        const r = await event.locals.pb.collection('users').update<User>(safeParams.id, safeData)
+
         if (safeData.password) {
-            const r = await event.locals.pb.collection('users').authWithPassword(safeData.email ?? safeData.username!, safeData.password);
-            return json(r.record)
-        } else {
-            return json(r);
+            const authR = await event.locals.pb.collection('users').authWithPassword(safeData.email ?? event.locals.pb.authStore.record!.email, safeData.password);
+            return json(authR.record)
         }
+        return json(r);
     } catch (e: any) {
         return handleError(e);
     }

--- a/web/src/routes/api/v1/user/[id]/email/+server.ts
+++ b/web/src/routes/api/v1/user/[id]/email/+server.ts
@@ -24,6 +24,8 @@ export async function POST(event: RequestEvent) {
         });
         event.locals.pb.authStore.save(emailChange.token, emailChange.record);
 
+        emailChange.record.email = email;
+
         return json(emailChange.record);
     } catch (e: any) {
         return handleError(e);

--- a/web/src/routes/api/v1/user/[id]/email/+server.ts
+++ b/web/src/routes/api/v1/user/[id]/email/+server.ts
@@ -1,0 +1,31 @@
+import { handleError } from '$lib/util/api_util';
+import { json, type RequestEvent } from '@sveltejs/kit';
+
+export async function POST(event: RequestEvent) {
+    try {
+        const { id } = event.params;
+
+        if (id !== event.locals.pb.authStore.record?.id) {
+            return json({ message: 'Forbidden' }, { status: 403 });
+        }
+
+        const { email, currentPassword } = await event.request.json();
+
+        if (!email) {
+            return json({ message: 'email is required' }, { status: 400 });
+        }
+        if (!currentPassword) {
+            return json({ message: 'currentPassword is required' }, { status: 400 });
+        }
+
+        const emailChange = await event.locals.pb.send('/user/email', {
+            method: 'POST',
+            body: JSON.stringify({ email, password: currentPassword }),
+        });
+        event.locals.pb.authStore.save(emailChange.token, emailChange.record);
+
+        return json(emailChange.record);
+    } catch (e: any) {
+        return handleError(e);
+    }
+}

--- a/web/src/routes/settings/account/+page.svelte
+++ b/web/src/routes/settings/account/+page.svelte
@@ -18,6 +18,7 @@
         logout,
         users_delete,
         users_update,
+        users_update_email,
     } from "$lib/stores/user_store";
     import { onMount } from "svelte";
     import { _ } from "svelte-i18n";
@@ -52,9 +53,9 @@
         goto("/");
     }
 
-    async function updateEmail(email: string) {
+    async function updateEmail(email: string, currentPassword: string) {
         try {
-            await users_update({ ...$currentUser!, email: email });
+            await users_update_email($currentUser!.id!, email, currentPassword);
             show_toast({
                 text: $_("email-updated"),
                 icon: "check",


### PR DESCRIPTION
Fixes an inconsistent email-change flow where the web UI showed an error even though the email was already changed. The user stayed logged in with stale auth state, which then caused follow-up errors in later actions.

Email changes now use a dedicated `POST /api/v1/user/{id}/email` flow with `currentPassword`, refreshed auth state, `verified=false`, and a new verification email. Normal user updates no longer process email changes: the API rejects `email` on `POST /api/v1/user/{id}`, while the client strips `email` from regular `users_update` payloads to avoid accidentally sending full auth records.