### PR TITLE
Allow public trails from users with private accounts to be seen

### DIFF
--- a/db/routes/remote_trail.go
+++ b/db/routes/remote_trail.go
@@ -93,7 +93,10 @@ func RemoteTrailGet(e *core.RequestEvent) error {
 func findLocalTrailByRemoteInfo(e *core.RequestEvent, ctx context.Context, handle, trailID string) (*core.Record, error) {
 	// 1. Get Actor to build the IRI
 	actor, err := federation.GetActorByHandle(e.App, ctx, handle, false)
-	if err != nil {
+	if err != nil && !errors.Is(err, federation.ErrProfilePrivate) {
+		return nil, err
+	}
+	if actor == nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Currently when a user has a private profile the trails of that user can be found via search but opon opening that trail it has a 404.

IMHO privacy settings from the user should not affect the trail visibility as mentioned in the settings page of the user:
(German variant but I am sure the english does state something similar: 

>"Nur Du kannst dein Profil sehen. Du wirst nicht in den Suchergebnissen angezeigt. Andere Benutzer können Dir nicht folgen oder Routen mit Dir teilen. Du kannst weiterhin Routen oder Listen veröffentlichen."

I assume PR https://github.com/open-wanderer/wanderer/pull/986/changes was meant to already fix that but it mostly just replaced the 500 by a 404