### PR TITLE
fix: restore remaining likes in Meilisearch on unlike

### DIFF
--- a/db/hooks/trail_like.go
+++ b/db/hooks/trail_like.go
@@ -85,18 +85,24 @@ func DeleteTrailLikeHandler(client meilisearch.ServiceManager) func(e *core.Reco
 		} else if err != nil {
 			return err
 		}
-		likes, err := e.App.CountRecords("trail_like", dbx.NewExp("trail={:trail}", dbx.Params{"trail": trailId}))
+		likes, err := e.App.FindAllRecords("trail_like",
+			dbx.NewExp("trail={:trail}", dbx.Params{"trail": trailId}),
+		)
 		if err != nil {
 			return err
 		}
 
-		trail.Set("like_count", likes)
+		trail.Set("like_count", len(likes))
 		err = e.App.UnsafeWithoutHooks().Save(trail)
 		if err != nil {
 			return err
 		}
 
-		err = util.UpdateTrailLikes(trailId, []string{}, client)
+		actorIds := make([]string, len(likes))
+		for i, r := range likes {
+			actorIds[i] = r.GetString("actor")
+		}
+		err = util.UpdateTrailLikes(trailId, actorIds, client)
 		if err != nil {
 			return err
 		}

--- a/web/src/lib/stores/trail_store.ts
+++ b/web/src/lib/stores/trail_store.ts
@@ -497,10 +497,6 @@ export async function searchResultToTrailList(hits: Hits<TrailSearchResult>): Pr
                     permission: "view",
                     trail: h.id,
                     actor: s,
-                })),
-                trail_like_via_trail: h.likes?.map(l => ({
-                    trail: h.id,
-                    actor: l,
                 }))
             }
         }


### PR DESCRIPTION
DeleteTrailLikeHandler was wiping all likes from Meilisearch on every unlike instead of sending the remaining ones. Broken "liked" filter for all other users until someone liked again or restart of meili.

