### PR TITLE
fix: use ActivityPub actor ID for shared trails/lists search token filtering

### DIFF
--- a/db/hooks/users.go
+++ b/db/hooks/users.go
@@ -12,8 +12,6 @@ import (
 
 func CreateUserHandler(client meilisearch.ServiceManager) func(e *core.RecordEvent) error {
 	return func(e *core.RecordEvent) error {
-		userId := e.Record.Id
-
 		err := createDefaultUserSettings(e.App, e.Record.Id)
 		if err != nil {
 			return err
@@ -26,10 +24,10 @@ func CreateUserHandler(client meilisearch.ServiceManager) func(e *core.RecordEve
 
 		searchRules := map[string]interface{}{
 			"lists": map[string]string{
-				"filter": "public = true OR author = " + actor.Id + " OR shares = " + userId,
+				"filter": "public = true OR author = " + actor.Id + " OR shares = " + actor.Id,
 			},
 			"trails": map[string]string{
-				"filter": "public = true OR author = " + actor.Id + " OR shares = " + userId,
+				"filter": "public = true OR author = " + actor.Id + " OR shares = " + actor.Id,
 			},
 		}
 

--- a/db/hooks/users.go
+++ b/db/hooks/users.go
@@ -17,26 +17,8 @@ func CreateUserHandler(client meilisearch.ServiceManager) func(e *core.RecordEve
 			return err
 		}
 
-		actor, err := util.ActorFromUser(e.App, e.Record)
+		_, err = util.ActorFromUser(e.App, e.Record)
 		if err != nil {
-			return err
-		}
-
-		searchRules := map[string]interface{}{
-			"lists": map[string]string{
-				"filter": "public = true OR author = " + actor.Id + " OR shares = " + actor.Id,
-			},
-			"trails": map[string]string{
-				"filter": "public = true OR author = " + actor.Id + " OR shares = " + actor.Id,
-			},
-		}
-
-		token, err := util.GenerateMeilisearchToken(searchRules, client)
-		if err != nil {
-			return err
-		}
-		e.Record.Set("token", token)
-		if err := e.App.Save(e.Record); err != nil {
 			return err
 		}
 

--- a/db/routes/search_token.go
+++ b/db/routes/search_token.go
@@ -16,7 +16,6 @@ func SearchToken(client meilisearch.ServiceManager) func(e *core.RequestEvent) e
 		}
 
 		if e.Auth != nil {
-			userId := e.Auth.Id
 			userActor, err := e.App.FindFirstRecordByData("activitypub_actors", "user", e.Auth.Id)
 			if err != nil {
 				return err
@@ -24,10 +23,10 @@ func SearchToken(client meilisearch.ServiceManager) func(e *core.RequestEvent) e
 
 			searchRules = map[string]any{
 				"lists": map[string]string{
-					"filter": "public = true OR author = " + userActor.Id + " OR shares = " + userId,
+					"filter": "public = true OR author = " + userActor.Id + " OR shares = " + userActor.Id,
 				},
 				"trails": map[string]string{
-					"filter": "public = true OR author = " + userActor.Id + " OR shares = " + userId,
+					"filter": "public = true OR author = " + userActor.Id + " OR shares = " + userActor.Id,
 				},
 			}
 		}


### PR DESCRIPTION
Is it the incorrect id used for comparing with the shared user?