### PR TITLE
feat(db): resilient HTTP client + correctness fixes for integration s…

### DIFF
--- a/db/integrations/hammerhead/hammerhead.go
+++ b/db/integrations/hammerhead/hammerhead.go
@@ -92,11 +92,12 @@ func SyncHammerhead(app core.App, client meilisearch.ServiceManager) error {
 		if hammerheadIntegration.After != "" {
 			t, err := time.Parse("2006-01-02", hammerheadIntegration.After)
 			if err != nil {
-				return err
+				warning := fmt.Sprintf("invalid hammerhead 'after' date %q for user %s: %v\n", hammerheadIntegration.After, userId, err)
+				fmt.Print(warning)
+				app.Logger().Warn(warning)
+				continue
 			}
-			t = t.UTC()
-
-			after = t.Unix()
+			after = t.UTC().Unix()
 		}
 
 		if hammerheadIntegration.Planned {
@@ -187,29 +188,27 @@ func (h *HammerheadApi) buildHeader() *BasicAuthToken {
 }
 
 func getToken(uri string, auth *BasicAuthToken) ([]byte, error) {
-	client := &http.Client{}
+	jsonStr := []byte(`{"grant_type": "password", "username": "` + auth.Key + `", "password": "` + auth.Value + `"}`)
 
-	var jsonStr = []byte(`{"grant_type": "password", "username": "` + auth.Key + `", "password": "` + auth.Value + `"}`)
-
-	req, err := http.NewRequest("POST", uri, bytes.NewBuffer(jsonStr))
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := client.Do(req)
+	resp, err := util.DoWithRetry(util.IntegrationHTTPClient, func() (*http.Request, error) {
+		req, err := http.NewRequest("POST", uri, bytes.NewReader(jsonStr))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		return req, nil
+	})
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := util.ReadAllLimited(resp.Body, util.MaxIntegrationDownloadBytes)
 		return nil, fmt.Errorf("error retrieving auth token from Hammerhead (%d): %s", resp.StatusCode, string(body))
 	}
 
-	return io.ReadAll(resp.Body)
+	return util.ReadAllLimited(resp.Body, util.MaxIntegrationDownloadBytes)
 }
 
 func (h *HammerheadApi) UploadActivities(e *core.RequestEvent) error {
@@ -259,8 +258,11 @@ func (h *HammerheadApi) UploadActivities(e *core.RequestEvent) error {
 	return nil
 }
 
+// sendPostRequest uploads data to Hammerhead. It is deliberately NOT retried:
+// the only caller (UploadActivities) submits a user-provided file, and a blind
+// retry on a transient 5xx could create a duplicate route on Hammerhead's side.
+// It still uses the shared timeout client so an upload cannot hang forever.
 func sendPostRequest(url string, body io.Reader, contentType string, auth *BasicAuthToken) ([]byte, error) {
-	client := &http.Client{}
 	req, err := http.NewRequest("POST", url, body)
 	if err != nil {
 		return nil, err
@@ -274,43 +276,42 @@ func sendPostRequest(url string, body io.Reader, contentType string, auth *Basic
 		auth.Apply(req)
 	}
 
-	resp, err := client.Do(req)
+	resp, err := util.IntegrationHTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := util.ReadAllLimited(resp.Body, util.MaxIntegrationDownloadBytes)
 		return nil, fmt.Errorf("error sending request to Hammerhead (%d): %s", resp.StatusCode, string(body))
 	}
 
-	return io.ReadAll(resp.Body)
+	return util.ReadAllLimited(resp.Body, util.MaxIntegrationDownloadBytes)
 }
 
 func sendGetRequest(url string, auth *BasicAuthToken) ([]byte, error) {
-	client := &http.Client{}
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	if auth != nil {
-		auth.Apply(req)
-	}
-
-	resp, err := client.Do(req)
+	resp, err := util.DoWithRetry(util.IntegrationHTTPClient, func() (*http.Request, error) {
+		req, err := http.NewRequest("GET", url, nil)
+		if err != nil {
+			return nil, err
+		}
+		if auth != nil {
+			auth.Apply(req)
+		}
+		return req, nil
+	})
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := util.ReadAllLimited(resp.Body, util.MaxIntegrationDownloadBytes)
 		return nil, fmt.Errorf("error sending request to Hammerhead (%d): %s", resp.StatusCode, string(body))
 	}
 
-	return io.ReadAll(resp.Body)
+	return util.ReadAllLimited(resp.Body, util.MaxIntegrationDownloadBytes)
 }
 
 func (h *HammerheadApi) Login(email, password string) error {
@@ -322,7 +323,9 @@ func (h *HammerheadApi) Login(email, password string) error {
 	}
 
 	var data LoginResponse
-	json.Unmarshal(body, &data)
+	if err := json.Unmarshal(body, &data); err != nil {
+		return fmt.Errorf("unable to parse Hammerhead login response: %w", err)
+	}
 
 	h.Token = data.Token
 	derivedUserID, err := extractUserIDFromToken(data.Token)
@@ -367,7 +370,9 @@ func (h *HammerheadApi) fetchActivities(page int) ([]HammerheadActivityResponse,
 	}
 
 	var data HammerheadActivitiesResponse
-	json.Unmarshal(body, &data)
+	if err := json.Unmarshal(body, &data); err != nil {
+		return nil, 0, fmt.Errorf("unable to parse Hammerhead activities response: %w", err)
+	}
 
 	tours := data.Tours
 
@@ -383,7 +388,9 @@ func (h *HammerheadApi) fetchTours(page int) ([]HammerheadTourResponse, int, err
 	}
 
 	var data HammerheadToursResponse
-	json.Unmarshal(body, &data)
+	if err := json.Unmarshal(body, &data); err != nil {
+		return nil, 0, fmt.Errorf("unable to parse Hammerhead tours response: %w", err)
+	}
 
 	tours := data.Data
 
@@ -399,7 +406,9 @@ func (h *HammerheadApi) fetchDetailedActivity(tour HammerheadActivityResponse) (
 	}
 
 	var data *HammerheadActivity
-	json.Unmarshal(body, &data)
+	if err := json.Unmarshal(body, &data); err != nil {
+		return nil, fmt.Errorf("unable to parse Hammerhead activity details: %w", err)
+	}
 	return data, nil
 }
 
@@ -412,7 +421,9 @@ func (h *HammerheadApi) fetchDetailedTour(tour HammerheadTourResponse) (*Hammerh
 	}
 
 	var data *HammerheadTour
-	json.Unmarshal(body, &data)
+	if err := json.Unmarshal(body, &data); err != nil {
+		return nil, fmt.Errorf("unable to parse Hammerhead tour details: %w", err)
+	}
 	return data, nil
 }
 

--- a/db/integrations/komoot/komoot.go
+++ b/db/integrations/komoot/komoot.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"strconv"
@@ -56,7 +55,12 @@ func SyncKomoot(app core.App, client meilisearch.ServiceManager) error {
 			Completed: true,
 			Merge:     trailmerge.DefaultIntegrationAutoMergeSettings(),
 		}
-		json.Unmarshal([]byte(komootString), &komootIntegration)
+		if err := json.Unmarshal([]byte(komootString), &komootIntegration); err != nil {
+			warning := fmt.Sprintf("unable to parse komoot integration for user %s: %v\n", userId, err)
+			fmt.Print(warning)
+			app.Logger().Warn(warning)
+			continue
+		}
 
 		if !komootIntegration.Active || komootIntegration.Email == "" || komootIntegration.Password == "" {
 			continue
@@ -128,28 +132,27 @@ func (k *KomootApi) buildHeader() *BasicAuthToken {
 }
 
 func sendRequest(url string, auth *BasicAuthToken) ([]byte, error) {
-	client := &http.Client{}
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	if auth != nil {
-		auth.Apply(req)
-	}
-
-	resp, err := client.Do(req)
+	resp, err := util.DoWithRetry(util.IntegrationHTTPClient, func() (*http.Request, error) {
+		req, err := http.NewRequest("GET", url, nil)
+		if err != nil {
+			return nil, err
+		}
+		if auth != nil {
+			auth.Apply(req)
+		}
+		return req, nil
+	})
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := util.ReadAllLimited(resp.Body, util.MaxIntegrationDownloadBytes)
 		return nil, fmt.Errorf("error sending request to komoot (%d): %s", resp.StatusCode, string(body))
 	}
 
-	return io.ReadAll(resp.Body)
+	return util.ReadAllLimited(resp.Body, util.MaxIntegrationDownloadBytes)
 }
 
 func (k *KomootApi) Login(email, password string) error {
@@ -161,7 +164,9 @@ func (k *KomootApi) Login(email, password string) error {
 	}
 
 	var data LoginResponse
-	json.Unmarshal(body, &data)
+	if err := json.Unmarshal(body, &data); err != nil {
+		return fmt.Errorf("unable to parse komoot login response: %w", err)
+	}
 
 	k.UserID = data.Username
 	k.Token = data.Password
@@ -177,7 +182,9 @@ func (k *KomootApi) fetchTours(page int) ([]KomootTour, int, error) {
 	}
 
 	var data KomootToursResponse
-	json.Unmarshal(body, &data)
+	if err := json.Unmarshal(body, &data); err != nil {
+		return nil, 0, fmt.Errorf("unable to parse komoot tours response: %w", err)
+	}
 
 	return data.Embedded.Tours, data.Page.TotalPages, nil
 }
@@ -190,7 +197,9 @@ func (k *KomootApi) fetchDetailedTour(tour KomootTour) (*DetailedKomootTour, err
 	}
 
 	var data *DetailedKomootTour
-	json.Unmarshal(body, &data)
+	if err := json.Unmarshal(body, &data); err != nil {
+		return nil, fmt.Errorf("unable to parse komoot tour details: %w", err)
+	}
 	return data, nil
 }
 

--- a/db/integrations/strava/strava.go
+++ b/db/integrations/strava/strava.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"strconv"
@@ -27,6 +26,11 @@ import (
 type StravaApi struct {
 	AceessToken string
 }
+
+// stravaPerPage is the page size requested from Strava's list endpoints. A page
+// returning fewer items than this marks the last page, so we stop paginating
+// without an extra request for an empty page.
+const stravaPerPage = 50
 
 func SyncStrava(app core.App, client meilisearch.ServiceManager) error {
 	integrations, err := app.FindAllRecords("integrations", dbx.NewExp("true"))
@@ -67,12 +71,18 @@ func SyncStrava(app core.App, client meilisearch.ServiceManager) error {
 
 		decryptedSecret, err := security.Decrypt(stravaIntegration.ClientSecret, encryptionKey)
 		if err != nil {
-			return err
+			warning := fmt.Sprintf("unable to decrypt strava client secret for user %s: %v\n", userId, err)
+			fmt.Print(warning)
+			app.Logger().Warn(warning)
+			continue
 		}
 
 		decryptedRefreshToken, err := security.Decrypt(stravaIntegration.RefreshToken, encryptionKey)
 		if err != nil {
-			return err
+			warning := fmt.Sprintf("unable to decrypt strava refresh token for user %s: %v\n", userId, err)
+			fmt.Print(warning)
+			app.Logger().Warn(warning)
+			continue
 		}
 
 		request := RefreshTokenRequest{
@@ -99,70 +109,77 @@ func SyncStrava(app core.App, client meilisearch.ServiceManager) error {
 		}
 
 		if stravaIntegration.Routes {
-			page := 1
-			hasMore := true
-			for hasMore {
-				routes, err := fetchStravaRoutes(r.AccessToken, page)
-				hasMore = len(routes) > 0
-				page += 1
+			for page := 1; ; page++ {
+				routes, err := fetchStravaRoutes(r.AccessToken, page, stravaPerPage)
 				if err != nil {
 					warning := fmt.Sprintf("error fetching routes from strava: %v\n", err)
 					fmt.Print(warning)
 					app.Logger().Warn(warning)
 					break
 				}
-				err = syncTrailsWithRoutes(app, client, ctx, stravaIntegration, r.AccessToken, userId, actor, routes)
-				if err != nil {
+				if len(routes) == 0 {
+					break
+				}
+				if err := syncTrailsWithRoutes(app, client, ctx, stravaIntegration, r.AccessToken, userId, actor, routes); err != nil {
 					warning := fmt.Sprintf("error syncing strava routes with trails: %v\n", err)
-					fmt.Print(warning)
-					app.Logger().Warn(warning)
-					continue
-				}
-			}
-		}
-		if stravaIntegration.Activities {
-			page := 1
-			hasMore := true
-			for hasMore {
-				var after int64 = 0
-				if stravaIntegration.After != "" {
-					t, err := time.Parse("2006-01-02", stravaIntegration.After)
-					if err != nil {
-						return err
-					}
-					t = t.UTC()
-
-					after = t.Unix()
-				}
-				activities, err := fetchStravaActivities(r.AccessToken, page, after)
-				hasMore = len(activities) > 0
-				page += 1
-				if err != nil {
-					warning := fmt.Sprintf("error fetching activities from strava: %v", err)
 					fmt.Print(warning)
 					app.Logger().Warn(warning)
 					break
 				}
-				err = syncTrailsWithActivities(app, client, ctx, stravaIntegration, r.AccessToken, userId, actor, activities)
-
+				if len(routes) < stravaPerPage {
+					break
+				}
+			}
+		}
+		if stravaIntegration.Activities {
+			var after int64 = 0
+			if stravaIntegration.After != "" {
+				t, err := time.Parse("2006-01-02", stravaIntegration.After)
 				if err != nil {
-					warning := fmt.Sprintf("error syncing strava activities with trails: %v", err)
+					warning := fmt.Sprintf("invalid strava 'after' date %q for user %s: %v\n", stravaIntegration.After, userId, err)
 					fmt.Print(warning)
 					app.Logger().Warn(warning)
-					continue
+				} else {
+					after = t.UTC().Unix()
 				}
 			}
 
+			for page := 1; ; page++ {
+				activities, err := fetchStravaActivities(r.AccessToken, page, stravaPerPage, after)
+				if err != nil {
+					warning := fmt.Sprintf("error fetching activities from strava: %v\n", err)
+					fmt.Print(warning)
+					app.Logger().Warn(warning)
+					break
+				}
+				if len(activities) == 0 {
+					break
+				}
+				if err := syncTrailsWithActivities(app, client, ctx, stravaIntegration, r.AccessToken, userId, actor, activities); err != nil {
+					warning := fmt.Sprintf("error syncing strava activities with trails: %v\n", err)
+					fmt.Print(warning)
+					app.Logger().Warn(warning)
+					break
+				}
+				if len(activities) < stravaPerPage {
+					break
+				}
+			}
 		}
 
 		b, err := json.Marshal(stravaIntegration)
 		if err != nil {
-			return err
+			warning := fmt.Sprintf("unable to marshal strava integration for user %s: %v\n", userId, err)
+			fmt.Print(warning)
+			app.Logger().Warn(warning)
+			continue
 		}
 		i.Set("strava", string(b))
-		err = app.Save(i)
-		if err != nil {
-			return err
+		if err := app.Save(i); err != nil {
+			warning := fmt.Sprintf("unable to save strava integration for user %s: %v\n", userId, err)
+			fmt.Print(warning)
+			app.Logger().Warn(warning)
+			continue
 		}
 	}
 
@@ -177,14 +194,14 @@ func GetStravaToken(request any) (*RefreshTokenResponse, error) {
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", stravaTokenURL, bytes.NewBuffer(requestBody))
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	resp, err := util.DoWithRetry(util.IntegrationHTTPClient, func() (*http.Request, error) {
+		req, err := http.NewRequest("POST", stravaTokenURL, bytes.NewReader(requestBody))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		return req, nil
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -202,17 +219,17 @@ func GetStravaToken(request any) (*RefreshTokenResponse, error) {
 	return &tokenResponse, nil
 }
 
-func fetchStravaRoutes(accessToken string, page int) ([]StravaRoute, error) {
-	stravaRoutesURL := fmt.Sprintf("https://www.strava.com/api/v3/athlete/routes?page=%d", page)
+func fetchStravaRoutes(accessToken string, page int, perPage int) ([]StravaRoute, error) {
+	stravaRoutesURL := fmt.Sprintf("https://www.strava.com/api/v3/athlete/routes?page=%d&per_page=%d", page, perPage)
 
-	req, err := http.NewRequest("GET", stravaRoutesURL, nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Authorization", "Bearer "+accessToken)
-
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	resp, err := util.DoWithRetry(util.IntegrationHTTPClient, func() (*http.Request, error) {
+		req, err := http.NewRequest("GET", stravaRoutesURL, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Authorization", "Bearer "+accessToken)
+		return req, nil
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -230,16 +247,17 @@ func fetchStravaRoutes(accessToken string, page int) ([]StravaRoute, error) {
 	return routes, nil
 }
 
-func fetchStravaActivities(accessToken string, page int, after int64) ([]StravaActivity, error) {
-	stravaRoutesURL := fmt.Sprintf("https://www.strava.com/api/v3/athlete/activities?page=%d&after=%d", page, after)
-	req, err := http.NewRequest("GET", stravaRoutesURL, nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Authorization", "Bearer "+accessToken)
+func fetchStravaActivities(accessToken string, page int, perPage int, after int64) ([]StravaActivity, error) {
+	stravaRoutesURL := fmt.Sprintf("https://www.strava.com/api/v3/athlete/activities?page=%d&per_page=%d&after=%d", page, perPage, after)
 
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	resp, err := util.DoWithRetry(util.IntegrationHTTPClient, func() (*http.Request, error) {
+		req, err := http.NewRequest("GET", stravaRoutesURL, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Authorization", "Bearer "+accessToken)
+		return req, nil
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -292,34 +310,29 @@ func syncTrailsWithRoutes(app core.App, client meilisearch.ServiceManager, ctx c
 func fetchRouteGPX(route StravaRoute, accessToken string) (*filesystem.File, error) {
 	url := fmt.Sprintf("https://www.strava.com/api/v3/routes/%s/export_gpx", route.IDStr)
 
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Authorization", "Bearer "+accessToken)
-
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		if resp.Body != nil {
-			resp.Body.Close()
+	resp, err := util.DoWithRetry(util.IntegrationHTTPClient, func() (*http.Request, error) {
+		req, err := http.NewRequest("GET", url, nil)
+		if err != nil {
+			return nil, err
 		}
-	}()
+		req.Header.Set("Authorization", "Bearer "+accessToken)
+		return req, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("failed to fetch GPX: received status %d", resp.StatusCode)
 	}
 
-	var buf bytes.Buffer
-	_, err = io.Copy(&buf, resp.Body)
+	data, err := util.ReadAllLimited(resp.Body, util.MaxIntegrationDownloadBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	gpxFile, err := filesystem.NewFileFromBytes(buf.Bytes(), route.Name+".gpx")
+	gpxFile, err := filesystem.NewFileFromBytes(data, route.Name+".gpx")
 	if err != nil {
 		return nil, err
 	}
@@ -467,14 +480,15 @@ func syncTrailsWithActivities(app core.App, client meilisearch.ServiceManager, c
 
 func fetchDetailedActivity(activity StravaActivity, accessToken string) (*DetailedStravaActivity, error) {
 	url := fmt.Sprintf("https://www.strava.com/api/v3/activities/%d", activity.ID)
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Authorization", "Bearer "+accessToken)
 
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	resp, err := util.DoWithRetry(util.IntegrationHTTPClient, func() (*http.Request, error) {
+		req, err := http.NewRequest("GET", url, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Authorization", "Bearer "+accessToken)
+		return req, nil
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -608,13 +622,9 @@ func createTrailFromActivity(app core.App, activity *DetailedStravaActivity, gpx
 }
 
 func fetchActivityPhoto(activity *DetailedStravaActivity) (*filesystem.File, error) {
-	req, err := http.NewRequest("GET", activity.Photos.Primary.Urls.Num600, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	resp, err := util.DoWithRetry(util.IntegrationHTTPClient, func() (*http.Request, error) {
+		return http.NewRequest("GET", activity.Photos.Primary.Urls.Num600, nil)
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -624,13 +634,12 @@ func fetchActivityPhoto(activity *DetailedStravaActivity) (*filesystem.File, err
 		return nil, fmt.Errorf("failed to fetch photo: received status %d", resp.StatusCode)
 	}
 
-	var buf bytes.Buffer
-	_, err = io.Copy(&buf, resp.Body)
+	data, err := util.ReadAllLimited(resp.Body, util.MaxIntegrationDownloadBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	photo, err := filesystem.NewFileFromBytes(buf.Bytes(), "photo")
+	photo, err := filesystem.NewFileFromBytes(data, "photo")
 	if err != nil {
 		return nil, err
 	}
@@ -641,15 +650,14 @@ func fetchActivityPhoto(activity *DetailedStravaActivity) (*filesystem.File, err
 func generateActivityGPX(activity *DetailedStravaActivity, accessToken string) (*filesystem.File, error) {
 	url := fmt.Sprintf("https://www.strava.com/api/v3/activities/%d/streams?keys=latlng,time,altitude&key_by_type=true", activity.ID)
 
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Authorization", "Bearer "+accessToken)
-
-	client := &http.Client{}
-
-	resp, err := client.Do(req)
+	resp, err := util.DoWithRetry(util.IntegrationHTTPClient, func() (*http.Request, error) {
+		req, err := http.NewRequest("GET", url, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Authorization", "Bearer "+accessToken)
+		return req, nil
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/db/util/httpclient.go
+++ b/db/util/httpclient.go
@@ -1,0 +1,130 @@
+package util
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"math/rand"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// IntegrationHTTPClient is the shared HTTP client for outbound requests to the
+// external fitness providers (Strava, Komoot, Hammerhead). Unlike a zero-value
+// http.Client it enforces an overall timeout, so a stalled provider connection
+// can never hang the nightly sync indefinitely.
+var IntegrationHTTPClient = &http.Client{
+	Timeout: 60 * time.Second,
+}
+
+const (
+	// MaxIntegrationDownloadBytes caps the size of a single downloaded payload
+	// (GPX export, photo, JSON response) so an unexpectedly huge or malicious
+	// response cannot exhaust memory during a sync.
+	MaxIntegrationDownloadBytes int64 = 100 << 20 // 100 MiB
+
+	integrationMaxAttempts   = 4
+	integrationBaseBackoff   = 500 * time.Millisecond
+	integrationMaxBackoff    = 30 * time.Second
+	integrationMaxRetryAfter = 60 * time.Second
+)
+
+// DoWithRetry executes an idempotent HTTP request, retrying on transient
+// failures: network errors, HTTP 429 (Too Many Requests) and 5xx responses. It
+// honors a Retry-After header when present and otherwise backs off
+// exponentially with jitter.
+//
+// newRequest is a factory rather than a *http.Request because a request body
+// can only be consumed once; each attempt needs a freshly built request. Use
+// this only for idempotent operations (GET, token refresh) - never for uploads
+// that would duplicate data when retried.
+func DoWithRetry(client *http.Client, newRequest func() (*http.Request, error)) (*http.Response, error) {
+	if client == nil {
+		client = IntegrationHTTPClient
+	}
+
+	var lastErr error
+	var wait time.Duration
+
+	for attempt := 1; attempt <= integrationMaxAttempts; attempt++ {
+		if wait > 0 {
+			time.Sleep(wait)
+		}
+
+		req, err := newRequest()
+		if err != nil {
+			return nil, err
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			lastErr = err
+			wait = backoffDuration(attempt, 0)
+			continue
+		}
+
+		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500 {
+			lastErr = fmt.Errorf("received status %d", resp.StatusCode)
+			retryAfter := parseRetryAfter(resp.Header.Get("Retry-After"))
+			resp.Body.Close()
+			wait = backoffDuration(attempt, retryAfter)
+			continue
+		}
+
+		return resp, nil
+	}
+
+	return nil, fmt.Errorf("request failed after %d attempts: %w", integrationMaxAttempts, lastErr)
+}
+
+// backoffDuration returns how long to wait before the next attempt. A positive
+// retryAfter (from a Retry-After header) takes precedence but is capped, so a
+// provider cannot stall a sync for an arbitrarily long time. Otherwise it grows
+// exponentially with the attempt number and adds jitter to avoid thundering herds.
+func backoffDuration(attempt int, retryAfter time.Duration) time.Duration {
+	if retryAfter > 0 {
+		if retryAfter > integrationMaxRetryAfter {
+			return integrationMaxRetryAfter
+		}
+		return retryAfter
+	}
+
+	backoff := float64(integrationBaseBackoff) * math.Pow(2, float64(attempt-1))
+	if backoff > float64(integrationMaxBackoff) {
+		backoff = float64(integrationMaxBackoff)
+	}
+	jitter := time.Duration(rand.Int63n(int64(integrationBaseBackoff)))
+	return time.Duration(backoff) + jitter
+}
+
+// parseRetryAfter interprets a Retry-After header value, which is either a
+// number of seconds or an HTTP date. Returns 0 when absent or unparseable.
+func parseRetryAfter(v string) time.Duration {
+	if v == "" {
+		return 0
+	}
+	if secs, err := strconv.Atoi(v); err == nil && secs >= 0 {
+		return time.Duration(secs) * time.Second
+	}
+	if t, err := http.ParseTime(v); err == nil {
+		if d := time.Until(t); d > 0 {
+			return d
+		}
+	}
+	return 0
+}
+
+// ReadAllLimited reads from r up to max bytes, returning an error if the source
+// exceeds the limit. Use it instead of io.ReadAll for response bodies whose size
+// is controlled by a remote server.
+func ReadAllLimited(r io.Reader, max int64) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(r, max+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > max {
+		return nil, fmt.Errorf("response exceeds maximum allowed size of %d bytes", max)
+	}
+	return data, nil
+}


### PR DESCRIPTION
…yncs

Outbound HTTP from the nightly integration sync has been hardened without introducing new endpoints or user-facing controls.

Shared resilient HTTP client (db/util/httpclient.go):
- 60s timeout on each request.
- DoWithRetry retries on network errors, HTTP 429, and 5xx with Retry-After honoring + exponential backoff with jitter.
- ReadAllLimited caps response bodies at 100 MiB to protect against pathologically large responses (e.g. an unexpectedly huge GPX export).

All Strava/Komoot/Hammerhead read paths now go through the new client. Uploads (Hammerhead activity upload) stay on a timeout-only client and do NOT retry — retrying an upload risks creating duplicate activities.

Correctness fixes that were quietly swallowing errors:
- Strava: per_page=50 pagination, stopping when a partial page is returned (previously stopped only on an empty page, requiring an extra round-trip).
- Strava: per-user decrypt/marshal/save errors now log and `continue` to the next user instead of aborting the whole nightly run.
- Strava: invalid `After` date no longer aborts the run.
- Komoot/Hammerhead: previously unchecked json.Unmarshal errors are now logged or returned with context.