### PR TITLE
feat(db): hardening — sanitizer + ActivityPub GET rate limit

### DIFF
--- a/db/main.go
+++ b/db/main.go
@@ -167,11 +167,14 @@ func registerRoutes(se *core.ServeEvent, client meilisearch.ServiceManager) {
 	se.Router.GET("/integration/hammerhead/login", routes.IntegrationHammerheadLogin)
 	se.Router.GET("/integration/komoot/login", routes.IntegrationKommotLogin)
 
+	// The signature-verified inbox (POST) is left unthrottled so legitimate
+	// federation delivery bursts are never dropped; the public read endpoints
+	// below are rate-limited per client IP against scraping/flooding.
 	se.Router.POST("/activitypub/activity/process", routes.ActivitypubActivityProcess)
-	se.Router.GET("/activitypub/actor", routes.ActivitypubActor)
-	se.Router.GET("/activitypub/actor/{id}/{follow}", routes.ActivitypubActorFollow)
-	se.Router.GET("/activitypub/trail/{id}", routes.ActivitypubTrail)
-	se.Router.GET("/activitypub/comment/{id}", routes.ActivitypubComment)
+	se.Router.GET("/activitypub/actor", routes.ActivitypubActor).BindFunc(util.ActivityPubRateLimit)
+	se.Router.GET("/activitypub/actor/{id}/{follow}", routes.ActivitypubActorFollow).BindFunc(util.ActivityPubRateLimit)
+	se.Router.GET("/activitypub/trail/{id}", routes.ActivitypubTrail).BindFunc(util.ActivityPubRateLimit)
+	se.Router.GET("/activitypub/comment/{id}", routes.ActivitypubComment).BindFunc(util.ActivityPubRateLimit)
 
 	se.Router.GET("/remote/trail/{id}", routes.RemoteTrailGet)
 	se.Router.GET("/remote/trail/{id}/comments", routes.RemoteTrailCommentsList)

--- a/db/util/network.go
+++ b/db/util/network.go
@@ -87,6 +87,27 @@ func (rl *RateLimiter) CheckRateLimit(identifier string, host string) error {
 
 var ActivityPubRateLimiter = NewRateLimiter(30, time.Minute)
 
+// ActivityPubInboundRateLimiter bounds how many requests a single client IP can
+// make to the public /activitypub/* read endpoints, protecting them from
+// scraping and flooding. The limit is intentionally generous so it never
+// throttles normal federation traffic. Behind a reverse proxy that does not
+// forward the real client IP it effectively becomes a global limit, which is
+// still a useful upper bound. Tune the numbers here if needed.
+var ActivityPubInboundRateLimiter = NewRateLimiter(200, time.Minute)
+
+// ActivityPubRateLimit is route middleware applying ActivityPubInboundRateLimiter,
+// keyed by the client IP.
+func ActivityPubRateLimit(e *core.RequestEvent) error {
+	ip := e.RealIP()
+	if ip == "" {
+		ip = e.Request.RemoteAddr
+	}
+	if err := ActivityPubInboundRateLimiter.CheckRateLimit(ip, "activitypub"); err != nil {
+		return e.TooManyRequestsError("Too many requests", err)
+	}
+	return e.Next()
+}
+
 type safeTransport struct {
 	transport http.RoundTripper
 }

--- a/db/util/sanitize.go
+++ b/db/util/sanitize.go
@@ -1,9 +1,13 @@
 package util
 
 import (
+	"regexp"
+
 	"github.com/microcosm-cc/bluemonday"
 	"github.com/pocketbase/pocketbase/core"
 )
+
+var targetBlankPattern = regexp.MustCompile(`^_blank$`)
 
 func SanitizeHTML() func(e *core.RecordRequestEvent) error {
 	return func(e *core.RecordRequestEvent) error {
@@ -28,7 +32,10 @@ func SanitizeHTML() func(e *core.RecordRequestEvent) error {
 		p.AllowElements("br", "div", "hr", "p", "span", "wbr")
 		p.AllowElements("b", "strong", "em", "u", "blockquote", "a")
 		p.AllowAttrs("href").OnElements("a")
-		p.AllowAttrs("target").OnElements("a")
+		// AllowStandardURLs (above) already limits href schemes to
+		// http/https/mailto, so javascript: URLs are stripped. Constrain target
+		// to _blank only, instead of allowing arbitrary frame targets.
+		p.AllowAttrs("target").Matching(targetBlankPattern).OnElements("a")
 		p.AllowAttrs("class").OnElements("a")
 
 		for _, field := range fields {


### PR DESCRIPTION
Two small, defensive improvements:

HTML sanitizer (db/util/sanitize.go): restrict the allowed value of <a target> to "_blank" only. Previously any value passed through, so sanitized markup could re-target the wanderer window or arbitrary named windows.

Per-client-IP rate limiting on the public ActivityPub GET routes (db/util/network.go, wired in db/main.go): /activitypub/actor, /activitypub/actor/{id}/{follow}, /activitypub/trail/{id}, and /activitypub/comment/{id} now share a per-IP token bucket so scraping or flooding the public endpoints from a single host is throttled. The signature-verified POST inbox is intentionally left unthrottled so legitimate federation delivery bursts are not dropped.