### PR TITLE
feat(db): optional superuser bootstrap from environment variables

### DIFF
--- a/db/hooks/bootstrap.go
+++ b/db/hooks/bootstrap.go
@@ -42,6 +42,59 @@ func OnBootstrapHandler() func(se *core.BootstrapEvent) error {
 			e.App.Settings().SMTP.Password = v
 		}
 
-		return e.App.Save(e.App.Settings())
+		if err := e.App.Save(e.App.Settings()); err != nil {
+			return err
+		}
+
+		createSuperuserFromEnv(e.App)
+
+		return nil
 	}
+}
+
+// createSuperuserFromEnv provisions an initial PocketBase superuser from the
+// POCKETBASE_SUPERUSER_EMAIL / POCKETBASE_SUPERUSER_PASSWORD environment
+// variables, so a fresh instance can be bootstrapped without the interactive
+// installer link.
+//
+// It is idempotent and conservative: if a superuser with that email already
+// exists it is left untouched, so a password later changed in the UI is never
+// reset on restart. Both variables must be set; if only one is provided this is
+// treated as a misconfiguration and logged. Failures are logged but never abort
+// startup - the operator can always fall back to the installer.
+func createSuperuserFromEnv(app core.App) {
+	email := os.Getenv("POCKETBASE_SUPERUSER_EMAIL")
+	password := os.Getenv("POCKETBASE_SUPERUSER_PASSWORD")
+
+	if email == "" && password == "" {
+		return
+	}
+	if email == "" || password == "" {
+		app.Logger().Warn("Skipping superuser bootstrap: both POCKETBASE_SUPERUSER_EMAIL and POCKETBASE_SUPERUSER_PASSWORD must be set")
+		return
+	}
+
+	superusers, err := app.FindCachedCollectionByNameOrId(core.CollectionNameSuperusers)
+	if err != nil {
+		app.Logger().Error("Failed to bootstrap superuser: cannot load the _superusers collection", "error", err)
+		return
+	}
+
+	if _, err := app.FindAuthRecordByEmail(superusers, email); err == nil {
+		// Already present - do not touch the existing account or its password.
+		return
+	}
+
+	superuser := core.NewRecord(superusers)
+	superuser.SetEmail(email)
+	superuser.SetPassword(password)
+
+	if err := app.Save(superuser); err != nil {
+		// Most commonly an invalid email or a password shorter than the
+		// collection minimum - Save returns a descriptive validation error.
+		app.Logger().Error("Failed to bootstrap superuser from environment", "email", email, "error", err)
+		return
+	}
+
+	app.Logger().Info("Created initial superuser from environment", "email", email)
 }


### PR DESCRIPTION
Allow provisioning the first PocketBase superuser at startup from POCKETBASE_SUPERUSER_EMAIL / POCKETBASE_SUPERUSER_PASSWORD, so a fresh container can come up without the operator having to follow the interactive installer link.

Opt-in: both variables must be set; neither set is a no-op. Setting only one is treated as a misconfiguration and logged.

Idempotent: the account is created only if no superuser with that email already exists. An existing password is never reset, so leaving the variables in the environment is safe.

Defensive: any failure (collection lookup, save) is logged via app.Logger().Error() and does not abort startup, so a misconfigured bootstrap can never prevent the app from coming up.