### PR TITLE
feat(db): allow overriding OIDC scopes via OIDC_SCOPES

### DIFF
--- a/db/main.go
+++ b/db/main.go
@@ -5,12 +5,14 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/meilisearch/meilisearch-go"
 	"github.com/pocketbase/dbx"
 	"github.com/pocketbase/pocketbase"
 	"github.com/pocketbase/pocketbase/core"
 	"github.com/pocketbase/pocketbase/plugins/migratecmd"
+	"github.com/pocketbase/pocketbase/tools/auth"
 
 	"pocketbase/commands"
 	"pocketbase/hooks"
@@ -67,6 +69,8 @@ func main() {
 
 	setupCommands(app)
 
+	configureOIDCScopes()
+
 	if err := app.Start(); err != nil {
 		log.Fatal(err)
 	}
@@ -77,6 +81,42 @@ func initializeMeilisearch() meilisearch.ServiceManager {
 		os.Getenv("MEILI_URL"),
 		meilisearch.WithAPIKey(os.Getenv("MEILI_MASTER_KEY")),
 	)
+}
+
+// configureOIDCScopes overrides the scopes requested by the oidc, oidc2 and
+// oidc3 providers with the comma separated list in OIDC_SCOPES.
+//
+// PocketBase asks every OIDC provider for "openid", "profile" and "email".
+// Not all providers accept those: OpenStreetMap, for instance, rejects the
+// authorization request outright rather than ignoring the unknown scopes, so
+// login fails before the user ever sees a consent screen. Such providers need
+// their own scope list ("openid,read_prefs" in the OSM case).
+func configureOIDCScopes() {
+	raw := os.Getenv("OIDC_SCOPES")
+	if raw == "" {
+		return
+	}
+
+	scopes := []string{}
+	for _, scope := range strings.Split(raw, ",") {
+		if scope = strings.TrimSpace(scope); scope != "" {
+			scopes = append(scopes, scope)
+		}
+	}
+
+	if len(scopes) == 0 {
+		return
+	}
+
+	factory := func() auth.Provider {
+		provider := auth.NewOIDCProvider()
+		provider.SetScopes(scopes)
+		return provider
+	}
+
+	for _, name := range []string{"oidc", "oidc2", "oidc3"} {
+		auth.Providers[name] = factory
+	}
 }
 
 func registerMigrations(app *pocketbase.PocketBase) {

--- a/db/main_test.go
+++ b/db/main_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/pocketbase/pocketbase/tools/auth"
+)
+
+func TestConfigureOIDCScopes(t *testing.T) {
+	defaultScopes := auth.Providers["oidc"]().Scopes()
+
+	scenarios := []struct {
+		name     string
+		env      string
+		expected []string
+	}{
+		{
+			name:     "unset leaves the provider defaults alone",
+			env:      "",
+			expected: defaultScopes,
+		},
+		{
+			name:     "single scope",
+			env:      "openid",
+			expected: []string{"openid"},
+		},
+		{
+			name:     "comma separated list",
+			env:      "openid,read_prefs",
+			expected: []string{"openid", "read_prefs"},
+		},
+		{
+			name:     "surrounding whitespace is ignored",
+			env:      " openid , read_prefs ",
+			expected: []string{"openid", "read_prefs"},
+		},
+		{
+			name:     "empty entries are dropped",
+			env:      "openid,,read_prefs,",
+			expected: []string{"openid", "read_prefs"},
+		},
+		{
+			name:     "only separators leaves the provider defaults alone",
+			env:      ",, ,",
+			expected: defaultScopes,
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+			// restore the stock factories so each scenario starts from the defaults
+			original := auth.Providers["oidc"]
+			t.Cleanup(func() {
+				for _, name := range []string{"oidc", "oidc2", "oidc3"} {
+					auth.Providers[name] = original
+				}
+			})
+
+			t.Setenv("OIDC_SCOPES", s.env)
+
+			configureOIDCScopes()
+
+			for _, name := range []string{"oidc", "oidc2", "oidc3"} {
+				scopes := auth.Providers[name]().Scopes()
+				if !slices.Equal(scopes, s.expected) {
+					t.Fatalf("%s: expected scopes %v, got %v", name, s.expected, scopes)
+				}
+			}
+		})
+	}
+}

--- a/docs/src/content/docs/run/backend-configuration/auth-providers.md
+++ b/docs/src/content/docs/run/backend-configuration/auth-providers.md
@@ -25,7 +25,11 @@ In the tab `OAuth2`, add your provider and fill in the Client ID and Client Secr
 
 <span class="-tracking-[0.075em]">wanderer</span> requests the scopes `openid`, `profile` and `email` from every OIDC provider. Some providers reject an authorization request that contains scopes they do not know, instead of ignoring them, and the login then fails before the consent screen appears.
 
-For those providers set `OIDC_SCOPES` on the `db` service to the list they expect. OpenStreetMap is one example — it accepts neither `profile` nor `email`:
+For those providers set `OIDC_SCOPES` on the `db` service to the list they expect. The list applies to the `oidc`, `oidc2` and `oidc3` providers.
+
+#### OpenStreetMap
+
+OSM accepts neither `profile` nor `email`, so it needs:
 
 ```yaml
 services:
@@ -33,8 +37,6 @@ services:
     environment:
       OIDC_SCOPES: "openid,read_prefs"
 ```
-
-The list applies to the `oidc`, `oidc2` and `oidc3` providers.
 
 ### Disable password authentication
 

--- a/docs/src/content/docs/run/backend-configuration/auth-providers.md
+++ b/docs/src/content/docs/run/backend-configuration/auth-providers.md
@@ -21,6 +21,21 @@ In any case, once you have successfully created your OAuth app you will receive 
 In the PocketBase admin panel navigate to the `users` table. Click the gear icon at the top to open the table's settings and navigate to `Options`.
 In the tab `OAuth2`, add your provider and fill in the Client ID and Client Secret from the step before and save your changes.
 
+### Providers that reject the default scopes
+
+<span class="-tracking-[0.075em]">wanderer</span> requests the scopes `openid`, `profile` and `email` from every OIDC provider. Some providers reject an authorization request that contains scopes they do not know, instead of ignoring them, and the login then fails before the consent screen appears.
+
+For those providers set `OIDC_SCOPES` on the `db` service to the list they expect. OpenStreetMap is one example — it accepts neither `profile` nor `email`:
+
+```yaml
+services:
+  db:
+    environment:
+      OIDC_SCOPES: "openid,read_prefs"
+```
+
+The list applies to the `oidc`, `oidc2` and `oidc3` providers.
+
 ### Disable password authentication
 
 After enabling the neccessary OAuth2 providers for your application you may want to disable the standard local password authentication.

--- a/docs/src/content/docs/run/backend-configuration/auth-providers.md
+++ b/docs/src/content/docs/run/backend-configuration/auth-providers.md
@@ -38,6 +38,8 @@ services:
       OIDC_SCOPES: "openid,read_prefs"
 ```
 
+Accounts created through OSM currently get a generated username such as `users729068` rather than the OSM display name, because display names may contain characters the `username` field does not allow.
+
 ### Disable password authentication
 
 After enabling the neccessary OAuth2 providers for your application you may want to disable the standard local password authentication.

--- a/docs/src/content/docs/run/environment-configuration.md
+++ b/docs/src/content/docs/run/environment-configuration.md
@@ -33,6 +33,7 @@ Since we use an unmodified installation of meilisearch you can use all variables
 | POCKETBASE_SMTP_PORT           | The port number used to connect to the SMTP server                                                                |                       |
 | POCKETBASE_SMTP_USERNAME       | The username used to authenticate with the SMTP server                                                            |                       |
 | POCKETBASE_SMTP_PASSWORD       | The password used to authenticate with the SMTP server                                                            |                       |
+| OIDC_SCOPES                    | Comma-separated OIDC scopes for the `oidc`, `oidc2` and `oidc3` providers. Only needed for providers that reject the defaults, such as OpenStreetMap (`openid,read_prefs`). See [Auth providers](/run/backend-configuration/auth-providers) | openid,profile,email |
 
 Plugins are not configured through an environment variable. See
 [Plugin installation](/run/installation/plugins) for installing runtime plugin

--- a/docs/src/content/docs/use/authentication.md
+++ b/docs/src/content/docs/use/authentication.md
@@ -39,7 +39,7 @@ Alternatively, <span class="-tracking-[0.075em]">wanderer</span> supports authen
 - Strava
 - LiveChat
 - mailcow
-- OpenID Connect
+- OpenID Connect (including OpenStreetMap, see [auth providers](/run/backend-configuration/auth-providers/))
 
 ![wanderer OAuth](../../../assets/guides/wanderer_oauth.png)
 


### PR DESCRIPTION
## What changed

Adds an `OIDC_SCOPES` environment variable for the `db` service. When set, it replaces the scopes requested by the `oidc`, `oidc2` and `oidc3` providers with a comma-separated list. When unset, the PocketBase defaults are used, so existing installations are unaffected.

## Why

wanderer requests `openid`, `profile` and `email` from every OIDC provider. Some providers reject an authorization request that carries scopes they do not recognise, rather than ignoring the unknown ones — the login then fails before the user ever reaches the consent screen.

OpenStreetMap is such a provider: it accepts neither `profile` nor `email`, which makes it unusable as an OIDC provider today. With `OIDC_SCOPES: "openid,read_prefs"` it works.

PocketBase itself offers no way to configure this. `core.OAuth2ProviderConfig` (v0.38.0) exposes `PKCE`, the endpoint URLs, client credentials, display name and an `Extra` map, but no scope field — scopes come from the provider factory in `tools/auth`, which is why this is an override of the factory rather than a settings change.

## How it was tested

- `db/main_test.go` covers the unset case, a single scope, a comma-separated list, surrounding whitespace, empty entries, and a separators-only value. The last two fall back to the provider defaults.
- Running against a live OpenStreetMap OIDC app on a self-hosted instance: login fails without the variable and succeeds with `openid,read_prefs`.

## Notes

Whitespace around entries is trimmed and empty entries are dropped, so `"openid, read_prefs"` behaves as expected.

The scope list applies to all three OIDC provider slots. Configuring them separately would mean three variables; that seemed like the wrong trade until someone actually needs two different OIDC providers with two different non-default scope sets.

This PR previously also mapped the OAuth2 username from `preferred_username`. That has been split out — testing showed it needs sanitising against the `username` field pattern before it is safe, since OSM display names may contain spaces and other characters the field rejects. It will follow as a separate PR.


Addresses root cause 1 of #1026. Root cause 2 (the discarded display name) is left for a separate PR.
