### PR TITLE
fix polyline db field size

### DIFF
--- a/db/migrations/1778583700_updated_trails_polyline_max.go
+++ b/db/migrations/1778583700_updated_trails_polyline_max.go
@@ -1,0 +1,36 @@
+package migrations
+
+import (
+	"pocketbase/util"
+
+	"github.com/pocketbase/pocketbase/core"
+	m "github.com/pocketbase/pocketbase/migrations"
+)
+
+func init() {
+	m.Register(func(app core.App) error {
+		collection, err := app.FindCollectionByNameOrId("e864strfxo14pm4")
+		if err != nil {
+			return err
+		}
+
+		field, ok := collection.Fields.GetByName("polyline").(*core.TextField)
+		if ok {
+			field.Max = util.PolylineMaxLength
+		}
+
+		return app.Save(collection)
+	}, func(app core.App) error {
+		collection, err := app.FindCollectionByNameOrId("e864strfxo14pm4")
+		if err != nil {
+			return err
+		}
+
+		field, ok := collection.Fields.GetByName("polyline").(*core.TextField)
+		if ok {
+			field.Max = 0
+		}
+
+		return app.Save(collection)
+	})
+}

--- a/db/util/polyline.go
+++ b/db/util/polyline.go
@@ -10,6 +10,8 @@ import (
 	"github.com/twpayne/go-polyline"
 )
 
+const PolylineMaxLength = 5 * 1024 * 1024
+
 func ComputePolyline(app core.App, r *core.Record) (string, error) {
 	gpxPath := r.GetString("gpx")
 	if len(gpxPath) == 0 {
@@ -55,6 +57,10 @@ func SavePolyline(app core.App, r *core.Record) error {
 	encoded, err := ComputePolyline(app, r)
 	if err != nil {
 		return err
+	}
+	// Encoded polylines are ASCII-only, so byte length matches character length.
+	if len(encoded) > PolylineMaxLength {
+		return fmt.Errorf("polyline exceeds maximum length of %d characters", PolylineMaxLength)
 	}
 	r.Set("polyline", encoded)
 	if err := app.UnsafeWithoutHooks().Save(r); err != nil {


### PR DESCRIPTION
Introduced in #1012, polylines are now stored in the database. Accidentally, the maximum allowed length for polyline strings was left at PocketBase's default of 5000 characters, which is far too small for polylines.

In combination with missing size validation before saving polylines without hooks, this made it possible to save trails whose polyline exceeded that limit. Afterwards, however, further changes to those trails could fail because the regular PocketBase validation rejected the existing polyline value.

This PR resolves the issue by increasing the polyline field limit and validating the computed polyline length before saving it.