### PR TITLE
fix waypoint actor in ingetrations

### DIFF
--- a/db/integrations/komoot/komoot.go
+++ b/db/integrations/komoot/komoot.go
@@ -228,7 +228,7 @@ func syncTrailWithTours(app core.App, client meilisearch.ServiceManager, ctx con
 			app.Logger().Warn(fmt.Sprintf("Unable to create trail for tour '%s': %v", tour.Name, err))
 			continue
 		}
-		err = createWaypointsFromTour(app, detailedTour, user, trailid)
+		err = createWaypointsFromTour(app, detailedTour, actor.Id, trailid)
 		if err != nil {
 			app.Logger().Warn(fmt.Sprintf("Unable to create waypoints for tour '%s': %v", tour.Name, err))
 			continue
@@ -358,7 +358,7 @@ func createTrailFromTour(app core.App, k *KomootApi, detailedTour *DetailedKomoo
 	return trailid, nil
 }
 
-func createWaypointsFromTour(app core.App, tour *DetailedKomootTour, user string, trailid string) error {
+func createWaypointsFromTour(app core.App, tour *DetailedKomootTour, actor string, trailid string) error {
 	collection, err := app.FindCollectionByNameOrId("waypoints")
 	if err != nil {
 		return err
@@ -392,7 +392,7 @@ func createWaypointsFromTour(app core.App, tour *DetailedKomootTour, user string
 			"lat":                 wpLat,
 			"lon":                 wpLon,
 			"icon":                "circle",
-			"author":              user,
+			"author":              actor,
 			"distance_from_start": 0,
 			"trail":               trailid,
 		})

--- a/db/integrations/strava/strava.go
+++ b/db/integrations/strava/strava.go
@@ -276,7 +276,7 @@ func syncTrailsWithRoutes(app core.App, client meilisearch.ServiceManager, ctx c
 			app.Logger().Warn(fmt.Sprintf("Unable to create trail for route '%s': %v", route.Name, err))
 			continue
 		}
-		err = createWaypointsFromRoute(app, route, user, trailid)
+		err = createWaypointsFromRoute(app, route, actor.Id, trailid)
 		if err != nil {
 			app.Logger().Warn(fmt.Sprintf("Unable to create waypoints for route '%s': %v", route.Name, err))
 			continue
@@ -406,7 +406,7 @@ func createTrailFromRoute(app core.App, route StravaRoute, gpx *filesystem.File,
 	return trailid, err
 }
 
-func createWaypointsFromRoute(app core.App, route StravaRoute, user string, trailid string) error {
+func createWaypointsFromRoute(app core.App, route StravaRoute, actor string, trailid string) error {
 	collection, err := app.FindCollectionByNameOrId("waypoints")
 	if err != nil {
 		return err
@@ -420,7 +420,7 @@ func createWaypointsFromRoute(app core.App, route StravaRoute, user string, trai
 		record.Set("lat", wp.Latlng[0])
 		record.Set("lon", wp.Latlng[1])
 		record.Set("icon", "circle")
-		record.Set("author", user)
+		record.Set("author", actor)
 		record.Set("distance_from_start", wp.DistanceIntoRoute)
 		record.Set("trail", trailid)
 


### PR DESCRIPTION
`Unable to create waypoints for tour 'test': author: Failed to find all relation records with the provided ids.`


integrations still used users.id instead of activitypub_actors