### PR TITLE
fix (plugins): increase request size limits

### DIFF
--- a/plugins/hammerhead/hammerhead.go
+++ b/plugins/hammerhead/hammerhead.go
@@ -11,6 +11,8 @@ import (
 	"github.com/open-wanderer/wanderer/plugins/sdk"
 )
 
+const hammerheadJSONMaxBytes int64 = 16 * 1024 * 1024
+
 type hammerheadClient struct {
 	userID string
 	token  string
@@ -37,7 +39,7 @@ func login(email string, password string) (string, error) {
 		},
 		Expect: sdk.ResponseExpect{
 			ContentTypes: []string{"application/json"},
-			MaxBytes:     1048576,
+			MaxBytes:     hammerheadJSONMaxBytes,
 		},
 	}
 	response, body, err := sdk.HostRequest(spec)
@@ -92,7 +94,7 @@ func (c hammerheadClient) get(path string, query []sdk.QueryParam, out any) erro
 		},
 		Expect: sdk.ResponseExpect{
 			ContentTypes: []string{"application/json"},
-			MaxBytes:     1048576,
+			MaxBytes:     hammerheadJSONMaxBytes,
 		},
 	})
 	if err != nil {

--- a/plugins/hammerhead/main.go
+++ b/plugins/hammerhead/main.go
@@ -165,7 +165,7 @@ func prepareTrailSendV1() int32 {
 			},
 			Expect: sdk.ResponseExpect{
 				ContentTypes: []string{"application/json"},
-				MaxBytes:     1048576,
+				MaxBytes:     hammerheadJSONMaxBytes,
 			},
 		},
 	}

--- a/plugins/hammerhead/plugin.json
+++ b/plugins/hammerhead/plugin.json
@@ -81,7 +81,7 @@
       ]
     },
     "downloads": {
-      "maxBytes": 1048576,
+      "maxBytes": 16777216,
       "contentTypes": [
         "application/json"
       ]

--- a/plugins/strava/plugin.json
+++ b/plugins/strava/plugin.json
@@ -102,7 +102,7 @@
       "oauth_access_token"
     ],
     "downloads": {
-      "maxBytes": 1048576,
+      "maxBytes": 16777216,
       "contentTypes": [
         "application/json",
         "application/gpx+xml",

--- a/plugins/strava/strava.go
+++ b/plugins/strava/strava.go
@@ -12,6 +12,8 @@ import (
 	"github.com/open-wanderer/wanderer/plugins/sdk"
 )
 
+const stravaDownloadMaxBytes int64 = 16 * 1024 * 1024
+
 // Strava is migrating its API host: the new host "https://www.api-v3.strava.com"
 // is available from 2027-01-04 and the old one is retired on 2027-06-01 (June
 // 2026 Developer Program update). We cut over on 2027-03-01 — after the new host
@@ -132,7 +134,7 @@ func (c *stravaClient) request(path string, query []sdk.QueryParam, contentTypes
 		},
 		Expect: sdk.ResponseExpect{
 			ContentTypes: contentTypes,
-			MaxBytes:     1048576,
+			MaxBytes:     stravaDownloadMaxBytes,
 		},
 	})
 }


### PR DESCRIPTION
The previous 1 MiB limit was too low for some large activity detail responses, especially long trails with many track points.