### PR TITLE
Auto set date of summit logs

### DIFF
--- a/web/src/lib/components/summit_log/summit_log_modal.svelte
+++ b/web/src/lib/components/summit_log/summit_log_modal.svelte
@@ -126,6 +126,16 @@
         $data.elevation_gain = totals.elevationGain;
         $data.elevation_loss = totals.elevationLoss;
         $data.distance = totals.distance;
+        const gpxDate = gpxObject.trk
+            ?.at(0)
+            ?.trkseg?.at(0)
+            ?.trkpt?.at(0)
+            ?.time?.toISOString()
+            ?.substring(0, 10);
+
+        if (gpxDate !== undefined) {
+            $data.date = gpxDate;
+        }
         $data.expand!.gpx_data = trailData;
     }
 
@@ -144,7 +154,11 @@
     {#snippet content()}
         <form id="summit-log-form" class="modal-content space-y-4" use:form>
             <div class="flex">
-                <Datepicker name="date" label={$_("date")} error={$errors.date}
+                <Datepicker
+                    name="date"
+                    label={$_("date")}
+                    error={$errors.date}
+                    bind:value={$data.date}
                 ></Datepicker>
             </div>
             <div>


### PR DESCRIPTION
## What was changed

- `handleTrailSelection` now also sets the date of the summit log. the `Datepicker` had to be updated to react to the changes by `handleTrailSelection`
- I am sorry for the whitespace changes, if you let me know your formatter, I can reverse them

## Why the change was needed

- Automatic setting of the date streamlines the user experience. I already have forgotten it several times and was then confused about my stats. 

## How the change was tested

- Tested with a gpx file locally

## Any known limitations or side effects.

- None.