### PR TITLE
Set up dev/main branch model and release pipeline sync

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,7 +2,7 @@ name: Go
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, dev ]
     paths:
       - '.github/**'
       - 'db/**'

--- a/.github/workflows/guard_main.yaml
+++ b/.github/workflows/guard_main.yaml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches: [main]
 
+permissions: {}
+
 jobs:
   check-source:
     runs-on: ubuntu-latest

--- a/.github/workflows/guard_main.yaml
+++ b/.github/workflows/guard_main.yaml
@@ -11,8 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Verify head branch is a release branch
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
-          HEAD_REF="${{ github.head_ref }}"
           if [[ "$HEAD_REF" == release/v* ]]; then
             echo "OK: $HEAD_REF is allowed to merge into main"
           else

--- a/.github/workflows/guard_main.yaml
+++ b/.github/workflows/guard_main.yaml
@@ -1,0 +1,19 @@
+name: Guard Main Source Branch
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-source:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify head branch is a release branch
+        run: |
+          HEAD_REF="${{ github.head_ref }}"
+          if [[ "$HEAD_REF" == release/v* ]]; then
+            echo "OK: $HEAD_REF is allowed to merge into main"
+          else
+            echo "::error::PRs into main must come from a release/v* branch (got '$HEAD_REF'). Open your PR against 'dev' instead."
+            exit 1
+          fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -95,8 +95,9 @@ jobs:
       
       - name: Extract release notes
         id: changelog
+        env:
+          VERSION: ${{ needs.publish.outputs.version }}
         run: |
-          VERSION="${{ needs.publish.outputs.version }}"
           # Clean 'v' from v0.12.0 for awk if your changelog uses 0.12.0
           RAW_VER=${VERSION#v}
           CHANGELOG=$(awk -v ver="$RAW_VER" 'BEGIN {in_section=0} /^# / {if (in_section) exit; if ($2 == ver) in_section=1} in_section {print}' CHANGELOG.md)
@@ -129,8 +130,9 @@ jobs:
 
       - name: Merge main into a sync branch off dev
         id: merge
+        env:
+          VERSION: ${{ needs.publish.outputs.version }}
         run: |
-          VERSION="${{ needs.publish.outputs.version }}"
           BRANCH="sync/${VERSION}-into-dev"
 
           git config user.name "github-actions[bot]"
@@ -145,16 +147,17 @@ jobs:
 
       - name: Create sync PR
         id: cpr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.publish.outputs.version }}
+          HEAD_BRANCH: ${{ steps.merge.outputs.branch }}
         run: |
-          VERSION="${{ needs.publish.outputs.version }}"
           URL=$(gh pr create \
             --base dev \
-            --head "${{ steps.merge.outputs.branch }}" \
+            --head "$HEAD_BRANCH" \
             --title "chore: sync ${VERSION} into dev" \
             --body "Automated sync of the ${VERSION} release (version bump + tag) back into dev.")
           echo "url=$URL" >> "$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable auto-merge
         run: gh pr merge --auto --merge "${{ steps.cpr.outputs.url }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -114,3 +114,49 @@ jobs:
             plugin_dist/SHA256SUMS
           draft: false
           prerelease: false
+
+  sync-dev:
+    needs: [publish, release]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Merge main into a sync branch off dev
+        id: merge
+        run: |
+          VERSION="${{ needs.publish.outputs.version }}"
+          BRANCH="sync/${VERSION}-into-dev"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git fetch origin dev
+          git checkout -b "$BRANCH" origin/dev
+          git merge --no-edit origin/main
+          git push origin "$BRANCH"
+
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Create sync PR
+        id: cpr
+        run: |
+          VERSION="${{ needs.publish.outputs.version }}"
+          URL=$(gh pr create \
+            --base dev \
+            --head "${{ steps.merge.outputs.branch }}" \
+            --title "chore: sync ${VERSION} into dev" \
+            --body "Automated sync of the ${VERSION} release (version bump + tag) back into dev.")
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge
+        run: gh pr merge --auto --merge "${{ steps.cpr.outputs.url }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_dev.yaml
+++ b/.github/workflows/release_dev.yaml
@@ -3,7 +3,7 @@ name: Publish dev Release
 on:
   push:
     branches:
-      - main
+      - dev
 
 jobs:
   docker-build:

--- a/.github/workflows/release_request.yaml
+++ b/.github/workflows/release_request.yaml
@@ -23,10 +23,11 @@ jobs:
           node-version: '22'
 
       - name: Bump versions
+        env:
+          VERSION: ${{ github.event.inputs.version }}
         run: |
-          VERSION=${{ github.event.inputs.version }}
-          cd web && npm version $VERSION --no-git-tag-version && cd ..
-          cd docs && npm version $VERSION --no-git-tag-version && cd ..
+          cd web && npm version "$VERSION" --no-git-tag-version && cd ..
+          cd docs && npm version "$VERSION" --no-git-tag-version && cd ..
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v8

--- a/.github/workflows/web.yaml
+++ b/.github/workflows/web.yaml
@@ -2,7 +2,7 @@ name: Web CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, dev ]
     paths:
       - '.github/**'
       - 'web/**'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,9 +18,13 @@ Please follow our [local development guide](https://wanderer.to/develop/local-de
 
 ## Pull Request Target Branch
 
-Please open pull requests only against the `main` branch.
+Please open pull requests only against the `dev` branch.
 
-Pull requests targeting release branches, development branches, or unrelated branches may be closed without review.
+Pull requests targeting `main`, release branches, or unrelated branches may be closed without review. `main` only accepts merges from `release/vX.Y.Z` branches as part of the release process (see below); it does not take pull requests directly.
+
+## Release Process
+
+Maintainers cut a release by dispatching the `Release Request` workflow **from the `dev` branch**. This bumps the version and opens a `release/vX.Y.Z` pull request against `main`. Merging that PR tags the release, publishes Docker images, and cuts a GitHub Release; the version bump and tag are then synced back into `dev` automatically via an auto-merging pull request.
 
 ## Keep pull requests atomic
 


### PR DESCRIPTION
Kindly note that the failing check of this PR is intentional and actually confirms guard_main.yaml works correctly.

- CI (`go.yml`, `web.yaml`): run on push to `dev` as well as `main` (PR triggers already covered `dev`)
- `release_dev.yaml`: rolling `:dev` GHCR image build now triggers on push to `dev` instead of `main`
- `release.yaml`: adds a `sync-dev` job that, after a release publishes, merges `main` back into `dev` via an auto-merging PR — keeps `dev`'s package versions and tag history from drifting after each release
- `guard_main.yaml` (new): required status check that fails any PR into `main` whose head branch isn't `release/v*`, since GitHub branch protection has no native "restrict source branch" rule. 
- `CONTRIBUTING.md`: points contributors at `dev` instead of `main`, documents the release flow

Branch protection rules on `main`/`dev` are configured separately in GitHub settings (not part of this PR).