### PR TITLE
fix(web): preserve share token in fullscreen map

### DIFF
--- a/web/src/lib/components/trail/trail_info_panel.svelte
+++ b/web/src/lib/components/trail/trail_info_panel.svelte
@@ -71,6 +71,7 @@
     } from "$lib/stores/trail_store";
     import Combobox, { type ComboboxItem } from "../base/combobox.svelte";
     import { tags_index } from "$lib/stores/tag_store";
+    import { withShareToken } from "$lib/util/url_util";
 
     interface Props {
         initTrail: Trail;
@@ -175,7 +176,12 @@
     }
 
     async function toggleMapFullScreen() {
-        goto(`/map/trail/${handle}/${trail.id!}`);
+        goto(
+            withShareToken(
+                `/map/trail/${handle}/${trail.id!}`,
+                page.url.searchParams,
+            ),
+        );
     }
 
     async function fetchComments() {

--- a/web/src/lib/util/url_util.test.ts
+++ b/web/src/lib/util/url_util.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { withShareToken } from "./url_util";
+
+describe("withShareToken", () => {
+    it("preserves the share token without forwarding unrelated state", () => {
+        const searchParams = new URLSearchParams({
+            share: "token+/=",
+            t: "2",
+        });
+
+        expect(
+            withShareToken("/map/trail/@alice/trail-id", searchParams),
+        ).toBe("/map/trail/@alice/trail-id?share=token%2B%2F%3D");
+    });
+
+    it("leaves paths without a share token unchanged", () => {
+        expect(
+            withShareToken(
+                "/map/trail/@alice/trail-id",
+                new URLSearchParams({ t: "2" }),
+            ),
+        ).toBe("/map/trail/@alice/trail-id");
+    });
+});

--- a/web/src/lib/util/url_util.ts
+++ b/web/src/lib/util/url_util.ts
@@ -1,0 +1,7 @@
+export function withShareToken(
+    path: string,
+    searchParams: URLSearchParams,
+): string {
+    const share = searchParams.get("share");
+    return share ? `${path}?${new URLSearchParams({ share })}` : path;
+}


### PR DESCRIPTION
Fixes #1136.

Reproduction: while signed out, open a shared trail link and use the fullscreen control on the small map. The destination loses the `share` query parameter, so the fullscreen map cannot load the trail.

This preserves only the existing `share` parameter when building the fullscreen URL. Other page query state is not forwarded.

Tests:
- `node node_modules/vitest/vitest.mjs run src/lib/models/trail.test.ts --reporter=verbose`
- `node node_modules/vitest/vitest.mjs run src/lib/util/format_util.test.ts --reporter=verbose`
- `node node_modules/vitest/vitest.mjs run src/lib/util/url_util.test.ts --reporter=verbose`
- `pnpm dlx npm@11.6.0 run check`
- `pnpm dlx npm@11.6.0 run build`

I couldn't run the Docker-backed Playwright suite locally because Docker is not installed; the unit, Svelte, and production build checks above passed.