### PR TITLE
chore: build with Go 1.26, Go 1.25 is out of support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,6 +49,17 @@ updates:
     cooldown:
       default-days: 7
   - package-ecosystem: "docker"
+    directory: "/db"
+    schedule:
+      interval: "monthly"
+    groups:
+      docker-db-backward-compatible:
+        update-types:
+          - minor
+          - patch
+    cooldown:
+      default-days: 7
+  - package-ecosystem: "docker"
     directory: "/docs"
     schedule:
       interval: "monthly"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,12 +19,12 @@ jobs:
   db-test:
     runs-on: ubuntu-latest
     env:
-      TINYGO_VERSION: '0.39.0'
+      TINYGO_VERSION: '0.41.1'
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
       - name: Install TinyGo
         run: |
           curl -fsSL "https://github.com/tinygo-org/tinygo/releases/download/v${TINYGO_VERSION}/tinygo_${TINYGO_VERSION}_amd64.deb" -o /tmp/tinygo.deb

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -75,14 +75,14 @@ jobs:
     permissions:
       contents: write
     env:
-      TINYGO_VERSION: '0.39.0'
+      TINYGO_VERSION: '0.41.1'
     steps:
       - uses: actions/checkout@v7
 
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
 
       - name: Install TinyGo
         run: |

--- a/.github/workflows/web.yaml
+++ b/.github/workflows/web.yaml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
 
       - run: make db-build-docker
 

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -28,7 +28,7 @@ RUN set -eux ; \
     tar -xJf /tmp/curl.tar.xz -C /tmp ; \
     chmod +x /tmp/curl ;
 
-FROM golang:1.25.0@sha256:5502b0e56fca23feba76dbc5387ba59c593c02ccc2f0f7355871ea9a0852cebe AS build
+FROM golang:1.26@sha256:9d2f36f06329b2a141b9db99ffa32765cf695ee57b813ca29e245e8670bcbfff AS build
 
 WORKDIR /app
 


### PR DESCRIPTION
## Why

Go 1.25 no longer receives security fixes: Go only supports the two most recent
major releases, and with Go 1.27.0 out, the supported lines are 1.26 and 1.27.

On top of that, the `wanderer-db` image was pinned by digest to `golang:1.25.0`
from August 2025 and never moved, because Dependabot had no Docker entry for
`/db`. So the images did not pick up patch releases. `govulncheck` on `main` reports 8 reachable
stdlib vulnerabilities in the binary, all fixed in current 1.26.x:

- GO-2026-6090, GO-2026-5856 (crypto/tls)
- GO-2026-6089, GO-2026-5026 (net/http, idna)
- GO-2026-6088 (encoding/xml), GO-2026-5972 (encoding/asn1)
- GO-2026-6218 (net/url), GO-2026-6091 (html/template)

## What

- `db/Dockerfile`: build stage now uses the `golang:1.26` tag pinned to the
  current multi-arch index digest (resolves to 1.26.8 today).
- `.github/dependabot.yml`: new Docker entry for `/db`, so the digest gets
  bumped whenever the `1.26` tag moves to the next patch release.
- Workflows (`go.yml`, `web.yaml`, `release.yaml`): `setup-go` on `1.26`,
  which resolves to the latest 1.26.x patch automatically.
- TinyGo `0.39.0` → `0.41.1`: 0.39 only supports up to Go 1.25, 0.41 adds
  Go 1.26 support. Needed for the plugin build in CI and the release job.
- `db/go.mod` keeps `go 1.25.0`. That line is a minimum, not a pin, and the
  1.26 toolchain builds the module unchanged.

## Verification

- `docker buildx build db/` succeeds with the new base image; the resulting
  binary reports `go1.26.8`.
- `go build ./...`, `go vet ./...` and `go test ./...` in `db/` pass with
  Go 1.26 locally.
- `make plugins-build` produces all three plugin WASM files with
  TinyGo 0.41.1 and Go 1.26.
