### PR TITLE
fix: refresh trail stats when replacing GPX

### DIFF
--- a/web/src/lib/util/api_util.ts
+++ b/web/src/lib/util/api_util.ts
@@ -123,11 +123,11 @@ export async function uploadCreate<T>(event: RequestEvent, collection: Collectio
     return r
 }
 
-export async function uploadUpdate<T>(event: RequestEvent, collection: Collection) {
+export async function uploadUpdate<T>(event: RequestEvent, collection: Collection, formData?: FormData) {
     const searchParams = Object.fromEntries(event.url.searchParams);
     const safeSearchParams = RecordOptionsSchema.parse(searchParams);
 
-    const data = await event.request.formData();
+    const data = formData ?? await event.request.formData();
     if (!data.has('id')) {
         throw new Error("data has no id")
     }

--- a/web/src/routes/api/v1/trail/form/[id]/+server.ts
+++ b/web/src/routes/api/v1/trail/form/[id]/+server.ts
@@ -1,6 +1,8 @@
 import type { Trail } from "$lib/models/trail";
 import { Collection, handleError, uploadUpdate } from "$lib/util/api_util";
+import { fromFile, gpx2trail } from "$lib/util/gpx_util";
 import { json, type RequestEvent } from "@sveltejs/kit";
+import { ClientResponseError } from "pocketbase";
 
 /**
  * @swagger
@@ -37,12 +39,37 @@ import { json, type RequestEvent } from "@sveltejs/kit";
  *         description: Internal Server Error
  */
 export async function POST(event: RequestEvent) {
-    try {        
-        const r = await uploadUpdate<Trail>(event, Collection.trails)
+    try {
+        const data = await event.request.formData();
+        await updateGPXStats(data, event);
+        const r = await uploadUpdate<Trail>(event, Collection.trails, data)
         enrichRecord(r);
         return json(r);
     } catch (e) {
         return handleError(e)
+    }
+}
+
+async function updateGPXStats(data: FormData, event: RequestEvent) {
+    const file = data.get("gpx");
+    if (!(file instanceof Blob)) {
+        return;
+    }
+
+    const { gpxData } = await fromFile(file);
+    if (!gpxData.length) {
+        throw new ClientResponseError({ status: 400, response: { message: "Empty file" } });
+    }
+
+    try {
+        const { trail } = await gpx2trail(gpxData, undefined, true, event.fetch);
+        data.set("distance", String(trail.distance ?? 0));
+        data.set("duration", String(trail.duration ?? 0));
+        data.set("elevation_gain", String(trail.elevation_gain ?? 0));
+        data.set("elevation_loss", String(trail.elevation_loss ?? 0));
+    } catch (e: any) {
+        console.error(e);
+        throw new ClientResponseError({ status: 400, response: { message: "Invalid file" } });
     }
 }
 

--- a/web/src/routes/api/v1/trail/form/[id]/server.test.ts
+++ b/web/src/routes/api/v1/trail/form/[id]/server.test.ts
@@ -1,0 +1,78 @@
+import type { RequestEvent } from "@sveltejs/kit";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fromFile, gpx2trail } from "$lib/util/gpx_util";
+import { POST } from "./+server";
+
+vi.mock("$lib/util/gpx_util", () => ({
+    fromFile: vi.fn(),
+    gpx2trail: vi.fn(),
+}));
+
+const derivedStats = {
+    distance: 5980.53,
+    duration: 3600,
+    elevation_gain: 123,
+    elevation_loss: 45,
+};
+
+describe("POST /api/v1/trail/form/[id]", () => {
+    const update = vi.fn();
+
+    beforeEach(() => {
+        update.mockReset();
+        update.mockResolvedValue({ id: "trail1234567890" });
+        vi.mocked(fromFile).mockReset();
+        vi.mocked(gpx2trail).mockReset();
+        vi.mocked(fromFile).mockResolvedValue({ gpxData: "<gpx />" } as never);
+        vi.mocked(gpx2trail).mockResolvedValue({ trail: derivedStats } as never);
+    });
+
+    it("recomputes the stored stats when replacing the GPX", async () => {
+        const data = formDataWithId();
+        data.set("gpx", new Blob(["replacement GPX"], { type: "application/gpx+xml" }));
+
+        const response = await POST(eventFor(data));
+
+        expect(response.status).toBe(200);
+        expect(gpx2trail).toHaveBeenCalledWith("<gpx />", undefined, true, expect.any(Function));
+        expect(Object.fromEntries(updatedData())).toMatchObject({
+            distance: "5980.53",
+            duration: "3600",
+            elevation_gain: "123",
+            elevation_loss: "45",
+        });
+    });
+
+    it("leaves stats untouched for a metadata-only update", async () => {
+        const data = formDataWithId();
+        data.set("name", "renamed trail");
+
+        const response = await POST(eventFor(data));
+
+        expect(response.status).toBe(200);
+        expect(gpx2trail).not.toHaveBeenCalled();
+        expect(updatedData().get("distance")).toBeNull();
+    });
+
+    function formDataWithId() {
+        const data = new FormData();
+        data.set("id", "trail1234567890");
+        return data;
+    }
+
+    function eventFor(data: FormData) {
+        return {
+            request: new Request("http://localhost/api/v1/trail/form/trail1234567890", {
+                method: "POST",
+                body: data,
+            }),
+            url: new URL("http://localhost/api/v1/trail/form/trail1234567890"),
+            fetch: vi.fn(),
+            locals: { pb: { collection: vi.fn(() => ({ update })) } },
+        } as unknown as RequestEvent;
+    }
+
+    function updatedData() {
+        return update.mock.calls[0][1] as FormData;
+    }
+});


### PR DESCRIPTION
## Why

Replacing a trail's GPX updated its geometry but kept the previous distance, duration, and elevation values.

## Verification

- Added route coverage for a GPX replacement and a metadata-only update.
- `npm run check`
- `npm run test:unit`
- Replaced a 6,004.53 m / 3,600 s trail with a 330.25 m / 600 s GPX and confirmed all four derived stats match a standalone upload.

Fixes #1199
