### PR TITLE
fix(media): disable video autoplay in lightbox and header galleries

### DIFF
--- a/web/src/lib/components/trail/trail_info_panel.svelte
+++ b/web/src/lib/components/trail/trail_info_panel.svelte
@@ -510,7 +510,6 @@
                             onclick={trail.photos.length
                                 ? () => gallery.openGallery(i)
                                 : null}
-                            autoplay
                             loop
                             src={photo}
                         ></video>

--- a/web/src/lib/vendor/photo-swipe-video-plugin/options.ts
+++ b/web/src/lib/vendor/photo-swipe-video-plugin/options.ts
@@ -10,7 +10,7 @@ export type PhotoSwipeVideoPluginOptions = {
 
 export const defaultOptions: PhotoSwipeVideoPluginOptions = {
     videoAttributes: { controls: '', playsinline: '', preload: 'auto' },
-    autoplay: true,
+    autoplay: false,
   
     // prevent drag/swipe gesture over the bottom part of video
     // set to 0 to disable


### PR DESCRIPTION
### Problem
Currently, videos embedded in trail galleries and the PhotoSwipe lightbox have autoplay enabled by default (`autoplay: true` in `PhotoSwipeVideoPlugin` options and `autoplay` attribute in `trail_info_panel.svelte`).

This leads to several user experience and performance drawbacks:
1. **Accessibility (WCAG 2.2.2 Pause, Stop, Hide)**: Automatic playback without explicit user action can be disorienting and intrusive.
2. **Performance & bandwidth**: Autoplaying high-resolution media immediately upon opening pages can consume unnecessary mobile data and battery.
3. **Sensory overload**: Multiple videos can attempt to play simultaneously when navigating through trail pages.

Note that `trail_timeline.svelte` already adopted a much friendlier pattern (only playing on hover or click).

### Solution
1. **PhotoSwipe Lightbox**:
   - Set `autoplay: false` by default in `PhotoSwipeVideoPlugin` options (`options.ts`) so fullscreen video playback only starts when the user explicitly clicks the play button.

2. **Trail Header Mosaic**:
   - In `trail_info_panel.svelte`, remove the `autoplay` attribute on the `<video>` element to prevent videos from automatically playing as soon as a trail page is opened.

### Changes Made
- `web/src/lib/vendor/photo-swipe-video-plugin/options.ts`: changed `defaultOptions.autoplay` from `true` to `false`.
- `web/src/lib/components/trail/trail_info_panel.svelte`: removed `autoplay` attribute from the header preview `<video>`.

### Testing
- Tested on modern browsers (Firefox, Chromium).
- Opening a trail page no longer autoplays header video media.
- Opening the PhotoSwipe lightbox on a video slide displays player controls and waits for user interaction instead of automatically playing.
- Image browsing remains completely fluid and unaffected.