### PR TITLE
fix(sync): preserve local sync state and isolate background records

### DIFF
--- a/db/routes/remote_background_sync_test.go
+++ b/db/routes/remote_background_sync_test.go
@@ -1,0 +1,140 @@
+package routes
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pocketbase/pocketbase/core"
+	pbtests "github.com/pocketbase/pocketbase/tests"
+	"github.com/pocketbase/pocketbase/tools/types"
+)
+
+type backgroundSyncTestApp struct {
+	core.App
+	synced chan error
+}
+
+func (app *backgroundSyncTestApp) RunInTransaction(fn func(core.App) error) error {
+	err := app.App.RunInTransaction(fn)
+	app.synced <- err
+	return err
+}
+
+func (app *backgroundSyncTestApp) CanAccessRecord(record *core.Record, info *core.RequestInfo, rule *string) (bool, error) {
+	// Finish the background mutation before the handler reads its response.
+	// Sharing the record then fails deterministically, without racing JSON export.
+	select {
+	case err := <-app.synced:
+		if err != nil {
+			return false, err
+		}
+	case <-time.After(5 * time.Second):
+		return false, fmt.Errorf("background sync did not finish")
+	}
+	return app.App.CanAccessRecord(record, info, rule)
+}
+
+type backgroundSyncTransport struct{}
+
+func (backgroundSyncTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(`{"id":"remote000000001","name":"Refreshed"}`)),
+	}, nil
+}
+
+func TestRemoteGetBackgroundSyncKeepsResponse(t *testing.T) {
+	t.Setenv("ORIGIN", "https://local.example")
+	originalClient := newRemoteSyncHTTPClient
+	newRemoteSyncHTTPClient = func() *http.Client {
+		return &http.Client{Transport: backgroundSyncTransport{}}
+	}
+	t.Cleanup(func() { newRemoteSyncHTTPClient = originalClient })
+
+	for _, tt := range []struct {
+		collection string
+		path       string
+		handler    func(*core.RequestEvent) error
+	}{
+		{"trails", "trail", RemoteTrailGet},
+		{"lists", "list", RemoteListGet},
+	} {
+		t.Run(tt.collection, func(t *testing.T) {
+			app, err := pbtests.NewTestApp(t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer app.Cleanup()
+			save := func(model core.Model) {
+				t.Helper()
+				if err := app.Save(model); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			actors := core.NewBaseCollection("activitypub_actors")
+			actors.Fields.Add(
+				&core.TextField{Name: "preferred_username"},
+				&core.TextField{Name: "domain"},
+				&core.TextField{Name: "iri"},
+				&core.BoolField{Name: "is_local"},
+				&core.DateField{Name: "last_fetched"},
+			)
+			save(actors)
+			actor := core.NewRecord(actors)
+			actor.Set("preferred_username", "alice")
+			actor.Set("domain", "remote.example")
+			actor.Set("iri", "https://remote.example/actor/alice")
+			actor.Set("last_fetched", time.Now())
+			save(actor)
+
+			collection := core.NewBaseCollection(tt.collection)
+			collection.ViewRule = types.Pointer("")
+			collection.Fields.Add(
+				&core.TextField{Name: "iri"},
+				&core.TextField{Name: "name"},
+				&core.BoolField{Name: "needs_full_sync"},
+				&core.BoolField{Name: "full_sync_completed"},
+				&core.DateField{Name: "updated"},
+			)
+			save(collection)
+			record := core.NewRecord(collection)
+			record.Set("name", "Cached")
+			record.Set("full_sync_completed", true)
+			record.Set("updated", time.Now().Add(-remoteSyncThreshold-time.Minute))
+			save(record)
+			record.Set("iri", "https://remote.example/api/v1/"+tt.path+"/"+record.Id)
+			save(record)
+
+			e := &core.RequestEvent{App: &backgroundSyncTestApp{App: app, synced: make(chan error, 1)}}
+			e.Request = httptest.NewRequest(http.MethodGet, "/api/v1/"+tt.path+"/"+record.Id+"?handle=alice@remote.example", nil)
+			e.Request.SetPathValue("id", record.Id)
+			response := httptest.NewRecorder()
+			e.Response = response
+			if err := tt.handler(e); err != nil {
+				t.Fatal(err)
+			}
+			var body struct{ Name string }
+			if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
+				t.Fatal(err)
+			}
+			if response.Code != http.StatusOK || body.Name != "Cached" {
+				t.Fatalf("response = %d %s, want original cached record", response.Code, response.Body.String())
+			}
+			updated, err := app.FindRecordById(tt.collection, record.Id)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if updated.GetString("name") != "Refreshed" {
+				t.Fatalf("stored name = %q, want Refreshed", updated.GetString("name"))
+			}
+		})
+	}
+}

--- a/db/routes/remote_list.go
+++ b/db/routes/remote_list.go
@@ -241,6 +241,7 @@ func syncListMetadata(record *core.Record, data map[string]any) {
 	delete(data, "author")
 	delete(data, "iri")
 
+	stripLocalSyncFields(data)
 	record.Load(data)
 }
 

--- a/db/routes/remote_list.go
+++ b/db/routes/remote_list.go
@@ -175,7 +175,7 @@ func performFullListSync(app core.App, ctx context.Context, reqURL *url.URL, loc
 		return localList, nil
 	}
 
-	client := util.SafeHTTPClient()
+	client := newRemoteSyncHTTPClient()
 	remoteUrl, _ := url.Parse(iri)
 	query := reqURL.Query()
 	query.Del("handle")

--- a/db/routes/remote_list.go
+++ b/db/routes/remote_list.go
@@ -77,9 +77,11 @@ func RemoteListGet(e *core.RequestEvent) error {
 				if _, alreadySyncing := listSyncing.LoadOrStore(iri, struct{}{}); !alreadySyncing {
 					urlCopy := *e.Request.URL
 					bgCtx := context.WithValue(context.Background(), "actor", ctx.Value("actor"))
+					// Sync hooks and remote data must not mutate the response record.
+					syncRecord := record.Fresh()
 					go func() {
 						defer listSyncing.Delete(iri)
-						performFullListSync(e.App, bgCtx, &urlCopy, record)
+						performFullListSync(e.App, bgCtx, &urlCopy, syncRecord)
 					}()
 				}
 			}

--- a/db/routes/remote_sync.go
+++ b/db/routes/remote_sync.go
@@ -1,5 +1,9 @@
 package routes
 
+import "pocketbase/util"
+
+var newRemoteSyncHTTPClient = util.SafeHTTPClient
+
 // stripLocalSyncFields removes local sync state from a remote payload.
 // Remote values must not mark a placeholder as complete or discard a
 // previously completed full sync.

--- a/db/routes/remote_sync.go
+++ b/db/routes/remote_sync.go
@@ -1,0 +1,9 @@
+package routes
+
+// stripLocalSyncFields removes local sync state from a remote payload.
+// Remote values must not mark a placeholder as complete or discard a
+// previously completed full sync.
+func stripLocalSyncFields(data map[string]any) {
+	delete(data, "needs_full_sync")
+	delete(data, "full_sync_completed")
+}

--- a/db/routes/remote_sync_flag_test.go
+++ b/db/routes/remote_sync_flag_test.go
@@ -1,0 +1,163 @@
+package routes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+	pbtests "github.com/pocketbase/pocketbase/tests"
+)
+
+// A list sync must preserve local sync state: placeholders need a full sync
+// before they can be served, while completed copies remain usable as a cache.
+func TestSyncTrailsKeepsLocalSyncFlags(t *testing.T) {
+	app, err := pbtests.NewTestApp(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer app.Cleanup()
+
+	trails := core.NewBaseCollection("trails")
+	trails.Fields.Add(
+		&core.TextField{Name: "iri"},
+		&core.TextField{Name: "name"},
+		&core.TextField{Name: "author"},
+		&core.BoolField{Name: "public"},
+		&core.BoolField{Name: "needs_full_sync"},
+		&core.BoolField{Name: "full_sync_completed"},
+		&core.NumberField{Name: "distance"},
+	)
+	if err := app.Save(trails); err != nil {
+		t.Fatal(err)
+	}
+
+	lists := core.NewBaseCollection("lists")
+	lists.Fields.Add(
+		&core.TextField{Name: "author"},
+		&core.RelationField{Name: "trails", CollectionId: trails.Id, MaxSelect: 100},
+	)
+	if err := app.Save(lists); err != nil {
+		t.Fatal(err)
+	}
+	list := core.NewRecord(lists)
+	list.Set("author", "actor0000000001")
+
+	const origin = "https://remote.example"
+	// Metadata import mutates the payload, so each sync needs a fresh copy.
+	remoteTrails := func(name string, needsSync, completed bool) []any {
+		return []any{map[string]any{
+			"id":                  "remote00000001",
+			"name":                name,
+			"public":              true,
+			"distance":            1234.5,
+			"needs_full_sync":     needsSync,
+			"full_sync_completed": completed,
+		}}
+	}
+
+	if err := syncTrails(app, context.Background(), list, origin, remoteTrails("Remote trail", false, true)); err != nil {
+		t.Fatalf("syncTrails: %v", err)
+	}
+
+	placeholder, err := app.FindFirstRecordByData("trails", "iri", origin+"/api/v1/trail/remote00000001")
+	if err != nil {
+		t.Fatalf("placeholder not created: %v", err)
+	}
+	if !placeholder.GetBool("needs_full_sync") {
+		t.Fatal("placeholder from list sync must stay needs_full_sync = true")
+	}
+	if placeholder.GetBool("full_sync_completed") {
+		t.Fatal("placeholder from list sync must stay full_sync_completed = false")
+	}
+	if cached := cachedRecordFallback(app, "trails", placeholder.Id, errRemoteUnavailable); cached != nil {
+		t.Fatal("placeholder must not be served as a completed cache")
+	}
+	if placeholder.GetString("name") != "Remote trail" || placeholder.GetFloat("distance") != 1234.5 || !placeholder.GetBool("public") {
+		t.Fatalf("metadata not loaded: %v", placeholder.PublicExport())
+	}
+	if got := list.GetStringSlice("trails"); len(got) != 1 || got[0] != placeholder.Id {
+		t.Fatalf("list.trails = %v, want [%s]", got, placeholder.Id)
+	}
+
+	// A copy that was fully synced before keeps that state when the list is
+	// synced again, even if the remote payload claims otherwise.
+	placeholder.Set("needs_full_sync", false)
+	placeholder.Set("full_sync_completed", true)
+	if err := app.Save(placeholder); err != nil {
+		t.Fatal(err)
+	}
+	if err := syncTrails(app, context.Background(), list, origin, remoteTrails("Updated trail", true, false)); err != nil {
+		t.Fatalf("syncTrails: %v", err)
+	}
+	synced, err := app.FindRecordById("trails", placeholder.Id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if synced.GetBool("needs_full_sync") {
+		t.Fatal("fully synced copy must not be flipped back to pending by the remote payload")
+	}
+	if !synced.GetBool("full_sync_completed") {
+		t.Fatal("fully synced copy must retain its local completion flag")
+	}
+	if synced.GetString("name") != "Updated trail" {
+		t.Fatalf("name = %q, want %q", synced.GetString("name"), "Updated trail")
+	}
+
+	// A later refresh request must still allow the completed copy as fallback.
+	synced.Set("needs_full_sync", true)
+	if err := app.Save(synced); err != nil {
+		t.Fatal(err)
+	}
+	if err := syncTrails(app, context.Background(), list, origin, remoteTrails("Updated trail", false, false)); err != nil {
+		t.Fatalf("syncTrails: %v", err)
+	}
+	cached := cachedRecordFallback(app, "trails", synced.Id, errRemoteUnavailable)
+	if cached == nil || cached.Id != synced.Id {
+		t.Fatal("completed copy must remain available as fallback while a refresh is pending")
+	}
+	if !cached.GetBool("needs_full_sync") {
+		t.Fatal("pending refresh must not be cleared by the remote payload")
+	}
+}
+
+func TestSyncListMetadataKeepsLocalSyncFlags(t *testing.T) {
+	lists := core.NewBaseCollection("lists")
+	lists.Fields.Add(
+		&core.TextField{Name: "name"},
+		&core.BoolField{Name: "needs_full_sync"},
+		&core.BoolField{Name: "full_sync_completed"},
+	)
+
+	for _, tt := range []struct {
+		name      string
+		needsSync bool
+		completed bool
+	}{
+		{"placeholder", true, false},
+		{"completed", false, true},
+		{"pending refresh", true, true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			record := core.NewRecord(lists)
+			record.Set("needs_full_sync", tt.needsSync)
+			record.Set("full_sync_completed", tt.completed)
+
+			syncListMetadata(record, map[string]any{
+				"id":                  "remote00000001",
+				"name":                "Remote list",
+				"needs_full_sync":     !tt.needsSync,
+				"full_sync_completed": !tt.completed,
+			})
+
+			if got := record.GetBool("needs_full_sync"); got != tt.needsSync {
+				t.Fatalf("needs_full_sync = %v, want local value %v", got, tt.needsSync)
+			}
+			if got := record.GetBool("full_sync_completed"); got != tt.completed {
+				t.Fatalf("full_sync_completed = %v, want local value %v", got, tt.completed)
+			}
+			if record.GetString("name") != "Remote list" {
+				t.Fatalf("name = %q, want %q", record.GetString("name"), "Remote list")
+			}
+		})
+	}
+}

--- a/db/routes/remote_trail.go
+++ b/db/routes/remote_trail.go
@@ -355,6 +355,7 @@ func syncTrailMetadata(app core.App, record *core.Record, data map[string]any) {
 	delete(data, "federated_category_name")
 	delete(data, "federated_subcategory_name")
 
+	stripLocalSyncFields(data)
 	record.Load(data)
 }
 

--- a/db/routes/remote_trail.go
+++ b/db/routes/remote_trail.go
@@ -133,9 +133,11 @@ func RemoteTrailGet(e *core.RequestEvent) error {
 				if _, alreadySyncing := trailSyncing.LoadOrStore(iri, struct{}{}); !alreadySyncing {
 					urlCopy := *e.Request.URL
 					bgCtx := context.WithValue(context.Background(), "actor", ctx.Value("actor"))
+					// Sync hooks and remote data must not mutate the response record.
+					syncRecord := record.Fresh()
 					go func() {
 						defer trailSyncing.Delete(iri)
-						performFullSync(e.App, bgCtx, &urlCopy, record)
+						performFullSync(e.App, bgCtx, &urlCopy, syncRecord)
 					}()
 				}
 			}

--- a/db/routes/remote_trail.go
+++ b/db/routes/remote_trail.go
@@ -233,7 +233,7 @@ func performFullSync(app core.App, ctx context.Context, reqURL *url.URL, localTr
 		return localTrail, nil
 	}
 
-	client := util.SafeHTTPClient()
+	client := newRemoteSyncHTTPClient()
 	remoteUrl, _ := url.Parse(iri)
 	query := reqURL.Query()
 	query.Del("handle")


### PR DESCRIPTION
Remote trail and list data could overwrite the local sync status. This could cause the first full sync to be skipped or incomplete cached data to be used. Background sync could also change a record while a request was checking access and preparing its response.

This fix preserves the local sync status and gives background sync a separate record copy, so it cannot change the response being prepared.
