### PR TITLE
fix(api): form/{id} updates are addressed by the path id

### DIFF
--- a/web/src/lib/util/api_util.ts
+++ b/web/src/lib/util/api_util.ts
@@ -124,16 +124,25 @@ export async function uploadCreate<T>(event: RequestEvent, collection: Collectio
 }
 
 export async function uploadUpdate<T>(event: RequestEvent, collection: Collection) {
+    const params = event.params
+    const safeParams = RecordIdSchema.parse(params);
+
     const searchParams = Object.fromEntries(event.url.searchParams);
     const safeSearchParams = RecordOptionsSchema.parse(searchParams);
 
     const data = await event.request.formData();
-    if (!data.has('id')) {
-        throw new Error("data has no id")
+
+    // The path is authoritative. An id in the body is optional but must
+    // agree with it, so a client cannot address one record and update another.
+    const bodyId = data.get('id');
+    if (bodyId !== null && bodyId !== safeParams.id) {
+        throw new ClientResponseError({
+            status: 400,
+            response: { message: "id_mismatch", expected: safeParams.id },
+        });
     }
 
-
-    const r = await event.locals.pb.collection(Collection[collection]).update<T>(data.get('id')!.toString(), data, safeSearchParams)
+    const r = await event.locals.pb.collection(Collection[collection]).update<T>(safeParams.id, data, safeSearchParams)
 
     return r
 }

--- a/web/src/routes/api/v1/list/form/[id]/+server.ts
+++ b/web/src/routes/api/v1/list/form/[id]/+server.ts
@@ -7,7 +7,8 @@ import { json, type RequestEvent } from "@sveltejs/kit";
  * /api/v1/list/form/{id}:
  *   post:
  *     summary: Update list with file upload
- *     description: Updates a list with file upload (avatar)
+ *     description: >
+ *       Updates a list with file upload (avatar). The record is addressed by the `id` path parameter; an `id` in the body is optional and must match it (400 `id_mismatch` otherwise).
  *     tags:
  *       - Lists
  *     parameters:
@@ -26,7 +27,7 @@ import { json, type RequestEvent } from "@sveltejs/kit";
  *       200:
  *         description: List
  *       400:
- *         description: Bad Request
+ *         description: Bad Request (invalid id, or body `id` differs from the path)
  *       404:
  *         description: Not Found
  *       500:

--- a/web/src/routes/api/v1/summit-log/form/[id]/+server.ts
+++ b/web/src/routes/api/v1/summit-log/form/[id]/+server.ts
@@ -7,7 +7,8 @@ import { json, type RequestEvent } from "@sveltejs/kit";
  * /api/v1/summit-log/form/{id}:
  *   post:
  *     summary: Update summit log with file upload
- *     description: Updates a summit log with file upload (photos/GPX) and date normalization
+ *     description: >
+ *       Updates a summit log with file upload (photos/GPX) and date normalization. The record is addressed by the `id` path parameter; an `id` in the body is optional and must match it (400 `id_mismatch` otherwise).
  *     tags:
  *       - Summit Logs
  *     parameters:
@@ -30,7 +31,7 @@ import { json, type RequestEvent } from "@sveltejs/kit";
  *             schema:
  *               $ref: '#/components/schemas/SummitLog'
  *       400:
- *         description: Bad Request
+ *         description: Bad Request (invalid id, or body `id` differs from the path)
  *       404:
  *         description: Not Found
  *       500:

--- a/web/src/routes/api/v1/trail/form/[id]/+server.ts
+++ b/web/src/routes/api/v1/trail/form/[id]/+server.ts
@@ -7,7 +7,8 @@ import { json, type RequestEvent } from "@sveltejs/kit";
  * /api/v1/trail/form/{id}:
  *   post:
  *     summary: Update trail with file upload
- *     description: Updates a trail with file upload (GPX/photos) and date normalization
+ *     description: >
+ *       Updates a trail with file upload (GPX/photos) and date normalization. The record is addressed by the `id` path parameter; an `id` in the body is optional and must match it (400 `id_mismatch` otherwise).
  *     tags:
  *       - Trails
  *     parameters:
@@ -30,7 +31,7 @@ import { json, type RequestEvent } from "@sveltejs/kit";
  *             schema:
  *               $ref: '#/components/schemas/Trail'
  *       400:
- *         description: Bad Request
+ *         description: Bad Request (invalid id, or body `id` differs from the path)
  *       404:
  *         description: Not Found
  *       500:


### PR DESCRIPTION
Fixes #1198

`POST /api/v1/{trail,list,summit-log}/form/{id}` ignored the path and read the record id from the multipart body. Omitting it produced a 500 (`data has no id`); sending a different one updated *that* record instead of the addressed one.

### Changes
- `uploadUpdate()` validates and uses the path id.
- A body `id` stays optional (the web UI sends it via `objectToFormData`) but must match the path, otherwise `400 {"message":"id_mismatch","expected":"<path id>"}`.
- OpenAPI descriptions of the three `form/{id}` endpoints document the rule. Their `*UpdateInput` schemas already omitted `id`, so they are now accurate.

### Verified
Against a dev instance with a fresh trail:
- no `id` in body → 200, file replaced
- matching `id` → 200, unchanged behaviour
- mismatched `id` → 400 `id_mismatch`, target record untouched
- malformed path id → 400 `invalid_params`; unknown id → 404

---
Part of a stack: #1225 → #1226 → #1227 → #1228. This is the bottom layer.
